### PR TITLE
Migration

### DIFF
--- a/package/dnf-plugins-extras.spec
+++ b/package/dnf-plugins-extras.spec
@@ -146,7 +146,7 @@ packages to a repository on the local filesystem and generating repo metadata.
 Summary:	Migrate Plugin for DNF
 Requires:	python-dnf-plugins-extras-common = %{version}-%{release}
 Requires:	yum
-Requires:	dnf >= 0.6.5
+Requires:	python-dnf >= 0.6.5
 %if 0%{?fedora} < 23
 Provides:	dnf-plugins-extras-migrate = %{version}-%{release}
 Obsoletes:	dnf-plugins-extras-migrate <= 0.0.4-2

--- a/plugins/migrate.py
+++ b/plugins/migrate.py
@@ -235,23 +235,14 @@ class MigrateCommand(dnf.cli.Command):
         yum_exec = "/usr/bin/yum-deprecated"
         if not os.path.exists(yum_exec):
             yum_exec = "/usr/bin/yum"
-        convert_groups_cmd = ["groups", "mark-convert", "-C"]
         env_config = dict(os.environ, LANG="C", LC_ALL="C")
         logger.info(_("Migrating groups data..."))
-
-        # convert yum groups to objects
-        check_output([yum_exec,
-                      "--setopt=group_command=objects"]
-                     + convert_groups_cmd, env=env_config)
 
         # mark yum installed groups in dnf
         installed = self.get_yum_installed_groups(yum_exec)
         group_cmd = dnf.cli.commands.group.GroupCommand(self.cli)
         group_cmd._grp_setup()
         group_cmd._mark_install(installed)
-
-        # restore group types from config
-        check_output([yum_exec] + convert_groups_cmd)
 
     @staticmethod
     def get_yum_installed_groups(yum_exec):


### PR DESCRIPTION
Hey, we have broken dependency in rawhide:
```
yum has broken dependencies in the rawhide tree:
On x86_64:
        yum-3.4.3-505.fc23.noarch requires dnf-plugins-extras-migrate
On i386:
        yum-3.4.3-505.fc23.noarch requires dnf-plugins-extras-migrate
On armhfp:
        yum-3.4.3-505.fc23.noarch requires dnf-plugins-extras-migrate
Please resolve this as soon as possible.
```
@megaumi , can you change the migrate plugin require in spec to `python-dnf-plugins-extras-migrate`, please. We don't have python3 version of this plugin.

Also migrate plugin should be called from dnf python2 version: https://github.com/jsilhan/dnf/commit/3dbdfd51265001d532f6e5d614c423bb464e8ba1

@rholy , is it right, spec master?