### PR TITLE
spec: allow DNF 1.x.x

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -1,5 +1,5 @@
 %{!?dnf_lowest_compatible: %global dnf_lowest_compatible 0.6.4-2}
-%{!?dnf_not_compatible: %global dnf_not_compatible 1.0}
+%{!?dnf_not_compatible: %global dnf_not_compatible 2.0}
 
 Name:		dnf-plugins-extras
 Version:	0.0.7


### PR DESCRIPTION
The major version bump of DNF did not introduce any backwards incompatible changes.

I did just some sanity tests since I don't expect that something should break.