### PR TITLE
Add repoclosure --check option

### DIFF
--- a/doc/repoclosure.rst
+++ b/doc/repoclosure.rst
@@ -40,6 +40,9 @@ Options
 ``--repo <repoid>``
     Specify repo ids to query, can be specified multiple times (default is all enabled).
 
+``--check <repoid>``
+    Specify repo ids to check, can be specified multiple times (default is all enabled).
+
 ``--pkg <pkg``
     Check closure for this package only.
 
@@ -59,3 +62,8 @@ Display list of unresolved dependencies for rawhide repository::
 Display list of unresolved dependencies for zmap package from rawhide repository::
 
     dnf repoclosure --repoid rawhide --pkg zmap
+
+Display list of unresolved dependencies for myrepo, an add-on for the rawhide repository::
+
+    dnf repoclosure --repoid rawhide --check myrepo
+

--- a/tests/test_repoclosure.py
+++ b/tests/test_repoclosure.py
@@ -41,6 +41,24 @@ class TestRepoClosureFunctions(support.TestCase):
         repos = [repo.id for repo in self.cmd.base.repos.iter_enabled()]
         self.assertEqual(["main"], repos)
 
+    def test_check_option(self):
+        args = ["--check", "@commandline"]
+        self.cmd.base.repos.add(support.RepoStub("main"))
+        self.cmd.base.add_remote_rpm(os.path.join(self.path,
+            "noarch/foo-4-6.noarch.rpm"))
+        self.cmd.configure(args)
+        with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
+            self.cmd.run(args)
+            expected_out = ["package: foo-4-6.noarch from @commandline",
+                            "  unresolved deps:",
+                            "    bar = 4-6"]
+            self.assertEqual(stdout.getvalue()[:-1], "\n".join(expected_out))
+        args = ["--check", "main"]
+        self.cmd.configure(args)
+        with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
+            self.cmd.run(args)
+            self.assertEmpty(stdout.getvalue())
+
     def test_pkg_option(self):
         args = ["--pkg", "foo"]
         self.cmd.base.add_remote_rpm(os.path.join(self.path,


### PR DESCRIPTION
This option, like the --pkg option, narrows the scope of the dependency
closure check, but at the repository level rather than the package level.
This is particularly useful for add-on repositories, where you want to
check for dependency issues within the add-on repository itself but are
not concerned about issues within the underlying base repository, which
you may have no control over to fix things anyway. Limiting checks to
the repository or repositories of interest makes it much faster to check
than doing a full check over all repositories too.