### PR TITLE
Check all packages in repo specified with --check

### DIFF
--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -99,9 +99,12 @@ class RepoClosureCommand(dnf.cli.Command):
         if self.opts.check:
             checkpkgs = set()
             for repo in self.opts.check:
-                for pkgs_filtered in available.filter(reponame=repo):
+                for pkgs_filtered in self.base.sack.query().available().filter(reponame=repo):
                     checkpkgs.add(pkgs_filtered)
-            pkgs.intersection_update(checkpkgs)
+            if self.opts.pkglist:
+                pkgs.intersection_update(checkpkgs)
+            else:
+                pkgs = checkpkgs
 
         for pkg in pkgs:
             unresolved[pkg] = set()


### PR DESCRIPTION
When using repoclosure --check, I'd like to check all versions of packages in the specified repos for dependency close, not just the latest ones.

There's also a workaround here for something I've observed in F-23, in that using available.filter(latest=True) seems to return the latest versions of packages for each repository, not the latest versions across all repos, hence possibly including multiple versions of the same package from different repos
