### PR TITLE
DNF plugin that automatically use tor

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -415,6 +415,20 @@ Versionlock plugin takes a set of name/versions for packages and excludes all ot
 versions of those packages. This allows you to e.g. protect packages from being
 updated by newer versions.
 
+%package -n python3-dnf-plugins-extras-torproxy
+Summary:	Torproxy Plugin for DNF
+Requires:	python3-dnf-plugins-extras-common = %{version}-%{release}
+Requires:   python3-pycurl
+%if 0%{?fedora} >= 23
+Provides:	dnf-plugin-torproxy = %{version}-%{release}
+Provides:	dnf-plugins-extras-torproxy = %{version}-%{release}
+%endif
+
+%description -n python3-dnf-plugins-extras-torproxy
+Torproxy plugin force dnf to use tor to download packages. It make sure that
+tor is working and avoid leaking hostname by using the proper sock5 interface.
+
+
 %prep
 %autosetup
 mkdir python2 python3
@@ -557,6 +571,12 @@ PYTHONPATH="%{buildroot}%{python3_sitelib}:%{buildroot}%{python3_sitelib}/dnf-pl
 %config %{_sysconfdir}/dnf/plugins/versionlock.list
 %{python3_sitelib}/dnf-plugins/versionlock.*
 %{python3_sitelib}/dnf-plugins/__pycache__/versionlock.*
+
+%files -n python3-dnf-plugins-extras-torproxy
+%config %{_sysconfdir}/dnf/plugins/torproxy.conf
+%{python3_sitelib}/dnf-plugins/torproxy.*
+%{python3_sitelib}/dnf-plugins/__pycache__/torproxy.*
+
 
 %changelog
 * Sat Dec 12 2015 Igor Gnatenko <i.gnatenko.brain@gmail.com> 0.0.12-1

--- a/doc/torproxy.rst
+++ b/doc/torproxy.rst
@@ -1,0 +1,49 @@
+..
+  Copyright (C) 2016 Michael Scherer
+
+  This copyrighted material is made available to anyone wishing to use,
+  modify, copy, or redistribute it subject to the terms and conditions of
+  the GNU General Public License v.2, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY expressed or implied, including the implied warranties of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+  Public License for more details.  You should have received a copy of the
+  GNU General Public License along with this program; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+  source code or documentation are not subject to the GNU General Public
+  License and may only be used or replicated with the express permission of
+  Red Hat, Inc.
+
+===================
+DNF torproxy Plugin
+===================
+
+-----------
+Description
+-----------
+
+Automatically pass all traffic in the tor network, and abort if tor is not running or blocked, to avoid any kind
+of identity leak.
+
+However, if there is a specific proxy settings in the configuration, the plugin will not
+overwrite it, assuming that the user did set it on purpose.
+
+-------------
+Configuration
+-------------
+
+``/etc/dnf/plugins/torproxy.conf``
+
+The minimal content of conf file should contain ``main`` sections with ``enabled`` parameter, otherwise plugin will not work.::
+
+  [main]
+  enabled = true
+
+If you do not want to use the default setup of tor, ie running it on the localhost, you can also specify
+the port and host of the tor client in a torproxy section like this::
+
+  [torproxy]
+  port = 9050
+  hostname = tor.example.org
+

--- a/etc/dnf/plugins/CMakeLists.txt
+++ b/etc/dnf/plugins/CMakeLists.txt
@@ -1,3 +1,4 @@
 INSTALL (FILES local.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
+INSTALL (FILES torproxy.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
 INSTALL (FILES versionlock.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
 INSTALL (FILES versionlock.list DESTINATION ${SYSCONFDIR}/dnf/plugins)

--- a/etc/dnf/plugins/torproxy.conf
+++ b/etc/dnf/plugins/torproxy.conf
@@ -1,0 +1,10 @@
+[main]
+enabled = true
+
+[torproxy]
+# Host where tor is running, 127.0.0.1 is the default option 
+#host = 127.0.0.1
+
+# Port where tor is listening for the socks proxy, default is 9050
+#port = 9050
+

--- a/plugins/torproxy.py
+++ b/plugins/torproxy.py
@@ -1,0 +1,96 @@
+# torproxy.py
+# Make dnf operation go trough the tor network.
+#
+# Copyright (C) 2016 Michael Scherer
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import dnf
+import dnf.plugin
+import dnfpluginsextras
+import pycurl
+import json
+import io
+import iniparse.compat as ini
+
+from dnfpluginscore import _
+
+MSG = _('It seems that tor is not working, aborting the command.')
+
+
+class TorProxy(dnf.Plugin):
+
+    name = "torproxy"
+
+    def __init__(self, base, cli):
+        super(TorProxy, self).__init__(base, cli)
+        self.base = base
+        self.logger = dnfpluginsextras.logger
+
+    def _check_tor_working(self):
+
+        buf = io.BytesIO()
+
+        c = pycurl.Curl()
+
+        c.setopt(pycurl.URL, 'https://check.torproject.org/api/ip')
+        c.setopt(pycurl.PROXY, self._host)
+        c.setopt(pycurl.PROXYPORT, int(self._port))
+        c.setopt(pycurl.PROXYTYPE, pycurl.PROXYTYPE_SOCKS5_HOSTNAME)
+        c.setopt(pycurl.PROXYUSERNAME, 'check')
+        c.setopt(pycurl.PROXYPASSWORD, 'check')
+
+        c.setopt(c.WRITEFUNCTION, buf.write)
+
+        try:
+            c.perform()
+            result = json.loads(buf.getvalue().decode("ascii"))['IsTor']
+        # TODO fix me, need to have a better exception filter
+        except Exception as e:
+            print(e)
+            result = False
+
+        return result
+
+    def config(self):
+        conf = self.read_config(self.base.conf, "torproxy")
+        # TODO try/catch if the config no longer exist (but then, what
+        # should the default be ?)
+        if not conf.getboolean("main", "enabled"):
+            return
+
+        try:
+            self._port = conf.get("torproxy", "port")
+        except ini.Error:
+            self._port = '9050'
+
+        try:
+            self._host = conf.get("torproxy", "host")
+        except ini.Error:
+            self._host = '127.0.0.1'
+
+
+        if not self._check_tor_working():
+            raise dnf.exceptions.Error(MSG)
+
+        for name,repo in self.base.repos.items():
+            if not repo.proxy:
+                repo.proxy = 'socks5h://{}:{}'.format(self._host, self._port)
+                # set a password to use IsolateSOCKSAuth, see
+                # https://github.com/diocles/apt-transport-tor
+                repo.proxy_username = 'dnf_' + name
+                repo.proxy_password = 'dnf_' + name
+

--- a/plugins/torproxy.py
+++ b/plugins/torproxy.py
@@ -28,7 +28,7 @@ import iniparse.compat as ini
 
 from dnfpluginscore import _
 
-MSG = _('It seems that tor is not working, aborting the command.')
+MSG = _('It seems that tor is not working, network operations may fail.')
 
 
 class TorProxy(dnf.Plugin):
@@ -82,15 +82,13 @@ class TorProxy(dnf.Plugin):
         except ini.Error:
             self._host = '127.0.0.1'
 
-
         if not self._check_tor_working():
-            raise dnf.exceptions.Error(MSG)
+            self.logger.error(MSG)
 
-        for name,repo in self.base.repos.items():
+        for name, repo in self.base.repos.items():
             if not repo.proxy:
                 repo.proxy = 'socks5h://{}:{}'.format(self._host, self._port)
                 # set a password to use IsolateSOCKSAuth, see
                 # https://github.com/diocles/apt-transport-tor
                 repo.proxy_username = 'dnf_' + name
                 repo.proxy_password = 'dnf_' + name
-


### PR DESCRIPTION
This plugin will make sure that tor is enabled for packages
downloads and will verify that tor is working before doing
anything, in order to make sure nothing is leaking by error.

It also configure each connexion to go over a different tor
circuit, to make correlation harder.

This is the first time I wrote a dnf plugin, so I likely forgot something, and would like to get a review before merging. I am not sure if I should include PO update in the PR, so I left them out.