### PR TITLE
fix plural forms of lithuanian

### DIFF
--- a/po/lt.po
+++ b/po/lt.po
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: lt\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 or n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "X-Generator: Zanata 3.7.3\n"
 
 #: ../plugins/show_leaves.py:56


### PR DESCRIPTION
If system language is set to lithuanian no plugin is working. Similar issue https://bugzilla.redhat.com/show_bug.cgi?id=1283599#c11

```
Feb 16 18:02:15 ERROR Nepavyko įkelti įskiepio: versionlock
Feb 16 18:02:15 SUBDEBUG
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/dnf/plugin.py", line 124, in import_modules
    module = importlib.import_module(name)
  File "/usr/lib64/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/usr/lib/python3.4/site-packages/dnf-plugins/versionlock.py", line 21, in <module>
    from dnfpluginsextras import _, logger
  File "/usr/lib/python3.4/site-packages/dnfpluginsextras/__init__.py", line 27, in <module>
    _, P_ = dnf.i18n.translation('dnf-plugins-extras')
  File "/usr/lib/python3.4/site-packages/dnf/i18n.py", line 289, in translation
    t = dnf.pycomp.gettext.translation(name, fallback=True)
  File "/usr/lib64/python3.4/gettext.py", line 410, in translation
    t = _translations.setdefault(key, class_(fp))
  File "/usr/lib64/python3.4/gettext.py", line 160, in __init__
    self._parse(fp)
  File "/usr/lib64/python3.4/gettext.py", line 281, in _parse
    self.plural = c2py(plural)
  File "/usr/lib64/python3.4/gettext.py", line 74, in c2py
    raise ValueError('plural forms expression could be dangerous')
ValueError: plural forms expression could be dangerous
```