### PR TITLE
Change usage of add_remote_rpm according to new API

### DIFF
--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -67,11 +67,10 @@ class RepoManageCommand(dnf.cli.Command):
         if len(rpm_list) == 0:
             raise dnf.exceptions.Error(_("No files to process"))
 
-        for pkg in rpm_list:
-            try:
-                self.base.add_remote_rpm(pkg)
-            except IOError:
-                dnfpluginsextras.logger.warning(_("Could not open {}").format(pkg))
+        try:
+            self.base.add_remote_rpms(rpm_list)
+        except IOError:
+            dnfpluginsextras.logger.warning(_("Could not open {}").format(', '.join(rpm_list)))
 
         packages = [x for x in self.base.sack.query().available()]
         packages.sort()

--- a/tests/support.py
+++ b/tests/support.py
@@ -38,9 +38,12 @@ class BaseStub(object):
         self.sack = dnf.sack.Sack()
         self.repos = dnf.repodict.RepoDict()
 
-    def add_remote_rpm(self, path):
+    def add_remote_rpms(self, path_list):
         self.sack.create_cmdline_repo()
-        return self.sack.add_cmdline_package(path)
+        pkgs = []
+        for path in path_list:
+            pkgs.append(self.sack.add_cmdline_package(path))
+        return pkgs
 
 class BaseCliStub(object):
     """A class mocking `dnf.cli.cli.BaseCli`."""

--- a/tests/test_repoclosure.py
+++ b/tests/test_repoclosure.py
@@ -44,8 +44,8 @@ class TestRepoClosureFunctions(support.TestCase):
     def test_check_option(self):
         args = ["--check", "@commandline"]
         self.cmd.base.repos.add(support.RepoStub("main"))
-        self.cmd.base.add_remote_rpm(os.path.join(self.path,
-            "noarch/foo-4-6.noarch.rpm"))
+        self.cmd.base.add_remote_rpms([os.path.join(self.path,
+            "noarch/foo-4-6.noarch.rpm")])
         self.cmd.configure(args)
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
             self.cmd.run(args)
@@ -61,8 +61,8 @@ class TestRepoClosureFunctions(support.TestCase):
 
     def test_pkg_option(self):
         args = ["--pkg", "foo"]
-        self.cmd.base.add_remote_rpm(os.path.join(self.path,
-            "noarch/foo-4-6.noarch.rpm"))
+        self.cmd.base.add_remote_rpms([os.path.join(self.path,
+            "noarch/foo-4-6.noarch.rpm")])
         self.cmd.configure(args)
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
             self.cmd.run(args)
@@ -78,8 +78,8 @@ class TestRepoClosureFunctions(support.TestCase):
 
     def test_base(self):
         args = []
-        self.cmd.base.add_remote_rpm(os.path.join(self.path,
-            "noarch/foo-4-6.noarch.rpm"))
+        self.cmd.base.add_remote_rpms([os.path.join(self.path,
+            "noarch/foo-4-6.noarch.rpm")])
         self.cmd.configure(args)
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
             self.cmd.run(args)

--- a/tests/test_repograph.py
+++ b/tests/test_repograph.py
@@ -51,10 +51,10 @@ class TestRepoGraphFunctions(support.TestCase):
 
     def test_base(self):
         args = []
-        self.cmd.base.add_remote_rpm(os.path.join(self.path,
-            "noarch/foo-4-6.noarch.rpm"))
-        self.cmd.base.add_remote_rpm(os.path.join(self.path,
-            "noarch/bar-4-6.noarch.rpm"))
+        self.cmd.base.add_remote_rpms([os.path.join(self.path,
+            "noarch/foo-4-6.noarch.rpm")])
+        self.cmd.base.add_remote_rpms([os.path.join(self.path,
+            "noarch/bar-4-6.noarch.rpm")])
         self.cmd.configure(args)
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
             self.cmd.run(args)


### PR DESCRIPTION
The function add_remote_rpm now requires list of paths and returns list of
package objects.