### PR TITLE
Adjust to privatization of function from Sack.rpmdb_version()

### DIFF
--- a/plugins/debug.py
+++ b/plugins/debug.py
@@ -175,7 +175,7 @@ class DebugDumpCommand(dnf.cli.Command):
 
     def dump_rpmdb_versions(self):
         self.write("%%%%RPMDB VERSIONS\n")
-        version = self.base.sack.rpmdb_version(self.base.yumdb)
+        version = self.base.sack._rpmdb_version(self.base.yumdb)
         self.write("  all: %s\n" % version)
         return
 


### PR DESCRIPTION
To make more distinguishable API and private functions the def rpmdb_version was
renamed to _rpmdb_version, therefore it has to be reflected in DNF-extras.