### PR TITLE
DNF 2.0: Add system upgrade

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Michael Mraka <michael.mraka@redhat.com>
 Emil Renner Berthing <dnf@esmil.dk>
 Radek Holý <rholy@redhat.com>
 Ville Skyttä <ville.skytta@iki.fi>
+Štěpán Smetana <ssmetana@redhat.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,21 @@ MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")
 
 SET (SYSCONFDIR /etc)
 
+find_package (PkgConfig)
+
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (SYSTEMD systemd)
+  if (SYSTEMD_FOUND)
+    execute_process (COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=systemdsystemunitdir systemd
+                     OUTPUT_VARIABLE SYSTEMD_DIR
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif ()
+endif()
+
+if (NOT SYSTEMD_DIR)
+  set (SYSTEMD_DIR /usr/lib/systemd/system)
+endif ()
+
 ADD_SUBDIRECTORY (doc)
 ADD_SUBDIRECTORY (etc)
 ADD_SUBDIRECTORY (plugins)

--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -269,6 +269,47 @@ Provides:       %{name}-snapper = %{version}-%{release}
 %description -n python3-%{name}-snapper
 Snapper Plugin for DNF, Python 3 version. Creates snapshot every transaction.
 
+%package -n python2-%{name}-system-upgrade
+Summary:        System Upgrade Plugin for DNF
+Requires:       python-%{name}-common = %{?epoch:%{?epoch}:}%{version}-%{release}
+Requires:       python2-systemd
+%{?python_provide:%python_provide python2-%{name}-system-upgrade}
+
+Obsoletes:     fedup < 0.9.4
+Obsoletes:     dnf-plugin-system-upgrade < 0.10
+Obsoletes:     python2-dnf-plugin-system-upgrade < 0.10
+
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  systemd
+BuildRequires:  python2-systemd
+%{?system_requires}
+
+%description -n python2-%{name}-system-upgrade
+System Upgrade Plugin for DNF, Python 2 version. Enables offline system upgrades
+using the "dnf system-upgrade" command.
+
+%package -n python3-%{name}-system-upgrade
+Summary:        System Upgrade Plugin for DNF
+Requires:       python3-%{name}-common = %{?epoch:%{?epoch}:}%{version}-%{release}
+Requires:       python3-systemd
+%{?python_provide:%python_provide python3-%{name}-system-upgrade}
+Provides:       dnf-command(system-upgrade)
+Provides:       %{name}-system-upgrade = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       system-upgrade = %{?epoch:%{epoch}:}%{version}-%{release}
+
+Obsoletes:     fedup < 0.9.4
+Obsoletes:     dnf-plugin-system-upgrade < 0.10
+Obsoletes:     python3-dnf-plugin-system-upgrade < 0.10
+
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  systemd
+BuildRequires:  python3-systemd
+%{?systemd_requires}
+
+%description -n python3-%{name}-system-upgrade
+System Upgrade Plugin for DNF, Python 3 version. Enables offline system upgrades
+using the "dnf system-upgrade" command.
+
 %package -n python2-%{name}-tracer
 Summary:        Tracer Plugin for DNF
 Requires:       python2-%{name}-common = %{version}-%{release}
@@ -348,6 +389,11 @@ pushd python2
 popd
 pushd python3
   %make_install
+popd
+
+mkdir -p %{buildroot}%{_unitdir}/system-update.target.wants/
+pushd %{buildroot}%{_unitdir}/system-update.target.wants/
+  ln -sr ../dnf-system-upgrade.service
 popd
 
 %find_lang %{name}
@@ -443,6 +489,17 @@ PYTHONPATH="%{buildroot}%{python3_sitelib}:%{buildroot}%{python3_sitelib}/dnf-pl
 %files -n python3-%{name}-snapper
 %{python3_sitelib}/dnf-plugins/snapper.*
 %{python3_sitelib}/dnf-plugins/__pycache__/snapper.*
+
+%files -n python2-%{name}-system-upgrade
+%{_unitdir}/dnf-system-upgrade.service
+%{_unitdir}/system-update.target.wants/dnf-system-upgrade.service
+%{python2_sitelib}/dnf-plugins/system_upgrade.*
+
+%files -n python3-%{name}-system-upgrade
+%{_unitdir}/dnf-system-upgrade.service
+%{_unitdir}/system-update.target.wants/dnf-system-upgrade.service
+%{python3_sitelib}/dnf-plugins/system_upgrade.py
+%{python3_sitelib}/dnf-plugins/__pycache__/system_upgrade.*
 
 %files -n python2-%{name}-tracer
 %{python2_sitelib}/dnf-plugins/tracer.*

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -1,0 +1,167 @@
+..
+  Copyright (C) 2014-2016 Red Hat, Inc.
+
+  This copyrighted material is made available to anyone wishing to use,
+  modify, copy, or redistribute it subject to the terms and conditions of
+  the GNU General Public License v.2, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY expressed or implied, including the implied warranties of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+  Public License for more details.  You should have received a copy of the
+  GNU General Public License along with this program; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+  source code or documentation are not subject to the GNU General Public
+  License and may only be used or replicated with the express permission of
+  Red Hat, Inc.
+
+=========================
+DNF system-upgrade Plugin
+=========================
+
+-----------
+Description
+-----------
+
+``dnf system-upgrade`` can be used to upgrade a Fedora system to a new major
+release. It replaces fedup (the old Fedora Upgrade tool).
+
+--------
+Synopsis
+--------
+
+``dnf system-upgrade download --releasever VERSION [OPTIONS]``
+
+``dnf system-upgrade reboot``
+
+``dnf system-upgrade clean``
+
+``dnf system-upgrade log [NUMBER]``
+
+
+-----------
+Subcommands
+-----------
+
+``download``
+    Downloads everything needed to upgrade to a new major release.
+
+``reboot``
+    Prepares the system to perform the upgrade, and reboots to start the upgrade.
+    This can only be used after the ``download`` command completes successfully.
+
+``clean``
+    Remove previously-downloaded data. This happens automatically at the end of
+    a successful upgrade.
+
+``log``
+    Used to see a list of boots during which an upgrade was attempted, or show
+    the logs from an upgrade attempt. The logs for one of the boots can be shown
+    by specifying one of the numbers in the first column. Negative numbers can
+    be used to number the boots from last to first. For example, ``log -1`` can
+    be used to see the logs for the last upgrade attempt.
+
+-------
+Options
+-------
+
+``--releasever=VERSION``
+    REQUIRED. The version to upgrade to. Sets ``$releasever`` in all enabled
+    repos. Usually a number, or ``rawhide``.
+
+``--distro-sync``
+    Behave like ``dnf distro-sync``: always install packages from the new
+    release, even if they are older than the currently-installed version. This
+    is the default behavior.
+
+``--no-downgrade``
+    Behave like ``dnf update``: do not install packages from the new release
+    if they are older than what is currently installed. This is the opposite of
+    ``--distro-sync``. If both are specified, the last option will be used.
+
+``--datadir=DIRECTORY``
+    Save downloaded packages to ``DIRECTORY``. DIRECTORY must already exist.
+    This directory ``must`` be mounted automatically by the system or the
+    upgrade will not work. The default is ``/var/lib/dnf/system-update``.
+
+-----
+Notes
+-----
+
+``dnf system-upgrade reboot`` does not create a "System Upgrade" boot item. The
+upgrade will start regardless of which boot item is chosen.
+
+Since this is a DNF plugin, options accepted by ``dnf`` are also valid here.
+See :manpage:`dnf(8)` for more information.
+
+The ``fedup`` command is not provided, not even as an alias for
+``dnf system-upgrade``.
+
+----
+Bugs
+----
+
+Upgrading from install media (e.g. a DVD or .iso file) currently requires the
+user to manually set up a DNF repo and fstab entry for the media.
+
+--------
+Examples
+--------
+
+Typical upgrade usage
+---------------------
+
+``dnf system-upgrade download --releasever 26``
+
+``dnf system-upgrade reboot``
+
+Show logs from last upgrade attempt
+-----------------------------------
+
+``dnf system-upgrade log -1``
+
+--------------
+Reporting Bugs
+--------------
+
+Bugs should be filed here:
+
+  https://bugzilla.redhat.com/
+
+For more info on filing bugs, see the Fedora Project wiki:
+
+  https://fedoraproject.org/wiki/How_to_file_a_bug_report
+
+  https://fedoraproject.org/wiki/Bugs_and_feature_requests
+
+Please include ``/var/log/dnf.log`` and the output of
+``dnf system-upgrade log -1`` (if applicable) in your bug reports.
+
+Problems with dependency solving during download are best reported to the
+maintainers of the package(s) with the dependency problems.
+
+Similarly, problems encountered on your system after the upgrade completes
+should be reported to the maintainers of the affected components. In other
+words: if (for example) KDE stops working, it's best if you report that to
+the KDE maintainers.
+
+--------
+See Also
+--------
+
+:manpage:`dnf(8)`,
+:manpage:`dnf.conf(5)`,
+:manpage:`journalctl(1)`.
+
+Project homepage
+----------------
+
+https://github.com/rpm-software-management/dnf-plugins-extras
+
+-------
+Authors
+-------
+
+Will Woods <wwoods@redhat.com>
+
+Štěpán Smetana <ssmetana@redhat.com>

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -1,1 +1,2 @@
 ADD_SUBDIRECTORY (dnf)
+ADD_SUBDIRECTORY (systemd)

--- a/etc/systemd/CMakeLists.txt
+++ b/etc/systemd/CMakeLists.txt
@@ -1,0 +1,1 @@
+INSTALL (FILES dnf-system-upgrade.service DESTINATION ${SYSTEMD_DIR})

--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=System Upgrade
+ConditionPathExists=/system-update/.dnf-system-upgrade
+Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
+
+[Service]
+# Upgrade output goes to journal and on-screen.
+StandardOutput=journal+console
+# This won't exist after we delete the symlink; don't consider that an error.
+EnvironmentFile=-/system-update/.dnf-system-upgrade
+# We need the --releasever junk because there's no way for DNF plugins to
+# change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
+ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
+# Remove the symlink if it's still there, to protect against reboot loops.
+ExecStopPost=/usr/bin/rm -fv /system-update
+# If anything goes wrong, reboot back to the normal system.
+FailureAction=reboot
+
+[Install]
+WantedBy=system-update.target

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -15,5 +15,6 @@ INSTALL (FILES torproxy.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES tracer.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES versionlock.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES kickstart.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
+INSTALL (FILES system_upgrade.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 
 ADD_SUBDIRECTORY (dnfpluginsextras)

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -1,0 +1,536 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s): Will Woods <wwoods@redhat.com>
+
+"""system_upgrade.py - DNF plugin to handle major-version system upgrades."""
+
+from __future__ import unicode_literals
+
+import os
+import json
+
+from subprocess import call, check_call
+
+import dnf
+import dnf.cli
+from dnf.cli import CliError
+
+import uuid
+
+import logging
+from systemd import journal
+
+from distutils.version import StrictVersion
+
+try:
+    from dnf.i18n import translation
+except ImportError:
+    # adapted from dnf-1.1.4's dnf.i18n.translation()
+    def translation(name):
+        def ucd_wrapper(fnc):
+            return lambda *w: dnf.i18n.ucd(fnc(*w))
+        t = dnf.pycomp.gettext.translation(name, fallback=True)
+        return (ucd_wrapper(f) for f in dnf.pycomp.gettext_setup(t))
+
+TEXTDOMAIN = 'dnf-plugin-system-upgrade'    # NOTE: must match Makefile
+_, P_ = translation(TEXTDOMAIN)
+
+# Translators: This string is only used in unit tests.
+_("the color of the sky")
+
+DOWNLOAD_FINISHED_ID = uuid.UUID('9348174c5cc74001a71ef26bd79d302e')
+REBOOT_REQUESTED_ID = uuid.UUID('fef1cc509d5047268b83a3a553f54b43')
+UPGRADE_STARTED_ID = uuid.UUID('3e0a5636d16b4ca4bbe5321d06c6aa62')
+UPGRADE_FINISHED_ID = uuid.UUID('8cec00a1566f4d3594f116450395f06c')
+
+ID_TO_IDENTIFY_BOOTS = UPGRADE_STARTED_ID
+
+logger = logging.getLogger("dnf.plugin")
+
+DNFVERSION = StrictVersion(dnf.const.VERSION)
+
+PLYMOUTH = '/usr/bin/plymouth'
+DEFAULT_DATADIR = '/var/lib/dnf/system-upgrade'
+MAGIC_SYMLINK = '/system-update'
+SYSTEMD_FLAG_FILE = os.path.join(MAGIC_SYMLINK, '.dnf-system-upgrade')
+
+NO_KERNEL_MSG = _(
+    "No new kernel packages were found.")
+RELEASEVER_MSG = _(
+    "Need a --releasever greater than the current system version.")
+DOWNLOAD_FINISHED_MSG = _(  # Translators: do not change "reboot" here
+    "Download complete! Use 'dnf system-upgrade reboot' to start the upgrade.")
+CANT_RESET_RELEASEVER = _(
+    "Sorry, you need to use 'download --releasever' instead of '--network'")
+
+# --- Miscellaneous helper functions ------------------------------------------
+
+
+def reboot():
+    check_call(["systemctl", "reboot"])
+
+
+# DNF-FIXME: dnf.util.clear_dir() doesn't delete regular files :/
+def clear_dir(path):
+    for entry in os.listdir(path):
+        fullpath = os.path.join(path, entry)
+        try:
+            if os.path.isdir(fullpath):
+                dnf.util.rm_rf(fullpath)
+            else:
+                os.unlink(fullpath)
+        except OSError:
+            pass
+
+
+def checkReleaseVer(conf, target=None):
+    if dnf.rpm.detect_releasever(conf.installroot) == conf.releasever:
+        raise CliError(RELEASEVER_MSG)
+    if target and target != conf.releasever:
+        # it's too late to set releasever here, so this can't work.
+        # (see https://bugzilla.redhat.com/show_bug.cgi?id=1212341)
+        raise CliError(CANT_RESET_RELEASEVER)
+
+
+def checkDataDir(datadir):
+    if os.path.exists(datadir) and not os.path.isdir(datadir):
+        raise CliError(_("--datadir: File exists"))
+    # FUTURE NOTE: check for removable devices etc.
+
+
+def disable_blanking():
+    try:
+        tty = open('/dev/tty0', 'wb')
+        tty.write(b'\33[9;0]')
+    except Exception as e:
+        print("Screen blanking can't be disabled: %s" % e)
+
+# --- State object - for tracking upgrade state between runs ------------------
+
+
+# DNF-INTEGRATION-NOTE: basically the same thing as dnf.persistor.JSONDB
+class State(object):
+    statefile = '/var/lib/dnf/system-upgrade.json'
+
+    def __init__(self):
+        self._data = {}
+        self._read()
+
+    def _read(self):
+        try:
+            with open(self.statefile) as fp:
+                self._data = json.load(fp)
+        except IOError:
+            self._data = {}
+
+    def write(self):
+        dnf.util.ensure_dir(os.path.dirname(self.statefile))
+        with open(self.statefile, 'w') as outf:
+            json.dump(self._data, outf)
+
+    def clear(self):
+        if os.path.exists(self.statefile):
+            os.unlink(self.statefile)
+        self._read()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            self.write()
+
+    # helper function for creating properties. pylint: disable=protected-access
+    def _prop(option):  # pylint: disable=no-self-argument
+        def setprop(self, value):
+            self._data[option] = value
+
+        def getprop(self):
+            return self._data.get(option)
+        return property(getprop, setprop)
+
+    download_status = _prop("download_status")
+    datadir = _prop("datadir")
+    target_releasever = _prop("target_releasever")
+    system_releasever = _prop("system_releasever")
+
+    upgrade_status = _prop("upgrade_status")
+    distro_sync = _prop("distro_sync")
+    allow_erasing = _prop("allow_erasing")
+    best = _prop("best")
+    exclude = _prop("exclude")
+
+# --- Plymouth output helpers -------------------------------------------------
+
+
+class PlymouthOutput(object):
+    """A plymouth output helper class that filters duplicate calls, and stops
+    calling the plymouth binary if we fail to contact it."""
+    def __init__(self):
+        self.alive = True
+        self._last_args = dict()
+        self._last_msg = None
+
+    def _plymouth(self, cmd, *args):
+        dupe_cmd = (args == self._last_args.get(cmd))
+        if (self.alive and not dupe_cmd) or cmd == '--ping':
+            try:
+                self.alive = (call((PLYMOUTH, cmd) + args) == 0)
+            except OSError:
+                self.alive = False
+            self._last_args[cmd] = args
+        return self.alive
+
+    def ping(self):
+        return self._plymouth("--ping")
+
+    def message(self, msg):
+        if self._last_msg and self._last_msg != msg:
+            self._plymouth("hide-message", "--text", self._last_msg)
+        self._last_msg = msg
+        return self._plymouth("display-message", "--text", msg)
+
+    def set_mode(self, mode):
+        return self._plymouth("change-mode", "--" + mode)
+
+    def progress(self, percent):
+        return self._plymouth("system-update", "--progress", str(percent))
+
+# A single PlymouthOutput instance for us to use within this module
+Plymouth = PlymouthOutput()
+
+
+# A TransactionProgress class that updates plymouth for us.
+class PlymouthTransactionProgress(dnf.callback.TransactionProgress):
+    # NOTE: I'm cheating here - this isn't part of the public DNF API
+    action = dnf.yum.rpmtrans.LoggingTransactionDisplay().action
+
+    # pylint: disable=too-many-arguments
+    def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):
+        self._update_plymouth(package, action, ts_done, ts_total)
+
+    def _update_plymouth(self, package, action, current, total):
+        Plymouth.progress(int(100.0 * current / total))
+        Plymouth.message(self._fmt_event(package, action, current, total))
+
+    def _fmt_event(self, package, action, current, total):
+        action = self.action.get(action, action)
+        return "[%d/%d] %s %s..." % (current, total, action, package)
+
+# --- journal helpers -------------------------------------------------
+
+
+def find_boots(message_id):
+    """Find all boots with this message id.
+
+    Returns the entries of all found boots.
+    """
+    j = journal.Reader()
+    j.add_match(MESSAGE_ID=message_id.hex,  # identify the message
+                _UID=0)                     # prevent spoofing of logs
+
+    oldboot = None
+    for entry in j:
+        boot = entry['_BOOT_ID']
+        if boot == oldboot:
+            continue
+        oldboot = boot
+        yield entry
+
+
+def list_logs():
+    print(_('The following boots appear to contain upgrade logs:'))
+    n = -1
+    for n, entry in enumerate(find_boots(ID_TO_IDENTIFY_BOOTS)):
+        print('{} / {.hex}: {:%Y-%m-%d %H:%M:%S} {}→{}'.format(
+            n + 1,
+            entry['_BOOT_ID'],
+            entry['__REALTIME_TIMESTAMP'],
+            entry.get('SYSTEM_RELEASEVER', '??'),
+            entry.get('TARGET_RELEASEVER', '??')))
+    if n == -1:
+        print(_('-- no logs were found --'))
+
+
+def pick_boot(message_id, n):
+    boots = list(find_boots(message_id))
+    # Positive indices index all found boots starting with 1 and going forward,
+    # zero is the current boot, and -1, -2, -3 are previous going backwards.
+    # This is the same as journalctl.
+    try:
+        if n == 0:
+            raise IndexError
+        elif n > 0:
+            n -= 1
+        return boots[n]['_BOOT_ID']
+    except IndexError:
+        raise CliError(_("Cannot find logs with this index."))
+
+
+def show_log(n):
+    boot_id = pick_boot(ID_TO_IDENTIFY_BOOTS, n)
+    check_call(['journalctl', '--boot', boot_id.hex])
+
+CMDS = ['download', 'clean', 'reboot', 'upgrade', 'log']
+
+# --- The actual Plugin and Command objects! ----------------------------------
+
+
+class SystemUpgradePlugin(dnf.Plugin):
+    name = 'system-upgrade'
+
+    def __init__(self, base, cli):
+        super(SystemUpgradePlugin, self).__init__(base, cli)
+        if cli:
+            cli.register_command(SystemUpgradeCommand)
+
+
+class SystemUpgradeCommand(dnf.cli.Command):
+    aliases = ('system-upgrade', 'fedup')
+    summary = _("Prepare system for upgrade to a new release")
+
+    def __init__(self, cli):
+        super(SystemUpgradeCommand, self).__init__(cli)
+        self.state = State()
+
+    @staticmethod
+    def set_argparser(parser):
+        parser.add_argument("--datadir", default=DEFAULT_DATADIR,
+                            help=_("save downloaded data to this location"))
+        parser.add_argument("--no-downgrade", dest='distro_sync',
+                            action='store_false',
+                            help=_("keep installed packages if the new "
+                                   "release's version is older"))
+        parser.add_argument('tid', nargs=1, choices=CMDS,
+                            metavar="[%s]" % "|".join(CMDS))
+
+    def log_status(self, message, message_id):
+        "Log directly to the journal"
+        journal.send(message,
+                     MESSAGE_ID=message_id,
+                     PRIORITY=journal.LOG_NOTICE,
+                     SYSTEM_RELEASEVER=self.state.system_releasever,
+                     TARGET_RELEASEVER=self.state.target_releasever,
+                     DNF_VERSION=dnf.const.VERSION)
+
+    def configure(self):
+        self._call_sub("configure")
+
+    def run(self):
+        self._call_sub("run", self.opts)
+
+    def run_transaction(self):
+        self._call_sub("transaction")
+
+    def _call_sub(self, name, *args):
+        subfunc = getattr(self, name + '_' + self.opts.tid[0], None)
+        if callable(subfunc):
+            subfunc(*args)
+
+    # == configure_*: set up action-specific demands ==========================
+
+    def configure_download(self, *args):
+        self.cli.demands.root_user = True
+        self.cli.demands.resolving = True
+        self.cli.demands.available_repos = True
+        self.cli.demands.sack_activation = True
+        self.base.repos.all().pkgdir = self.opts.datadir
+        # We want to do the depsolve / download / transaction-test, but *not*
+        # run the actual RPM transaction to install the downloaded packages.
+        # Setting the "test" flag makes the RPM transaction a test transaction,
+        # so nothing actually gets installed.
+        # (It also means that we run two test transactions in a row, which is
+        # kind of silly, but that's something for DNF to fix...)
+        self.base.conf.tsflags.append("test")
+
+    def configure_reboot(self, *args):
+        # FUTURE: add a --debug-shell option to enable debug shell:
+        # systemctl add-wants system-update.target debug-shell.service
+        self.cli.demands.root_user = True
+
+    def configure_upgrade(self, *args):
+        # same as the download, but offline and non-interactive. so...
+        self.cli.demands.root_user = True
+        self.cli.demands.resolving = True
+        self.cli.demands.sack_activation = True
+        # use the saved value for --datadir, --allowerasing, etc.
+        self.opts.datadir = self.state.datadir
+        self.opts.distro_sync = self.state.distro_sync
+        self.cli.demands.allow_erasing = self.state.allow_erasing
+        self.base.conf.best = self.state.best
+        self.base.conf.exclude = self.state.exclude
+        self.base.repos.all().pkgdir = self.opts.datadir
+        # don't try to get new metadata, 'cuz we're offline
+        self.cli.demands.cacheonly = True
+        # and don't ask any questions (we confirmed all this beforehand)
+        self.base.conf.assumeyes = True
+        self.cli.demands.transaction_display = PlymouthTransactionProgress()
+
+    def configure_clean(self, *args):
+        self.cli.demands.root_user = True
+
+    def configure_log(self, *args):
+        pass
+
+    # == check_*: do any action-specific checks ===============================
+
+    def check_download(self, *args):
+        checkReleaseVer(self.base.conf, target=self.opts.releasever)
+        checkDataDir(self.opts.datadir)
+
+    def check_reboot(self, *args):
+        if not self.state.download_status == 'complete':
+            raise CliError(_("system is not ready for upgrade"))
+        if os.path.lexists(MAGIC_SYMLINK):
+            raise CliError(_("upgrade is already scheduled"))
+        # FUTURE: checkRPMDBStatus(self.state.download_transaction_id)
+
+    def check_upgrade(self, *args):
+        if not self.state.upgrade_status == 'ready':
+            raise CliError(  # Translators: do not change "reboot" here
+                _("use 'dnf system-upgrade reboot' to begin the upgrade"))
+        if os.readlink(MAGIC_SYMLINK) != self.state.datadir:
+            logger.info(_("another upgrade tool is running. exiting quietly."))
+            raise SystemExit(0)
+
+    # == run_*: run the action/prep the transaction ===========================
+
+    def run_help(self, extcmds):
+        self.parser.print_help()
+
+    def run_prepare(self, extcmds):
+        # make the magic symlink
+        os.symlink(self.state.datadir, MAGIC_SYMLINK)
+        # write releasever into the flag file so it can be read by systemd
+        with open(SYSTEMD_FLAG_FILE, 'w') as flagfile:
+            flagfile.write("RELEASEVER=%s\n" % self.state.target_releasever)
+        # set upgrade_status so that the upgrade can run
+        with self.state as state:
+            state.upgrade_status = 'ready'
+
+    def run_reboot(self, extcmds):
+        self.run_prepare([])
+
+        if not self.opts.tid[0] == "reboot":
+            return
+
+        self.log_status(_("Rebooting to perform upgrade."),
+                        REBOOT_REQUESTED_ID)
+        reboot()
+
+    def run_download(self, extcmds):
+        # Mark everything in the world for upgrade/sync
+        if self.opts.distro_sync:
+            self.base.distro_sync()
+        else:
+            self.base.upgrade_all()
+
+        if self.opts.datadir == DEFAULT_DATADIR:
+            dnf.util.ensure_dir(self.opts.datadir)
+
+        with self.state as state:
+            state.download_status = 'downloading'
+            state.target_releasever = self.base.conf.releasever
+            state.datadir = self.opts.datadir
+            state.exclude = self.base.conf.exclude
+
+    def run_upgrade(self, extcmds):
+        # Delete symlink ASAP to avoid reboot loops
+        dnf.yum.misc.unlink_f(MAGIC_SYMLINK)
+        # change the upgrade status (so we can detect crashed upgrades later)
+        with self.state as state:
+            state.upgrade_status = 'incomplete'
+
+        self.log_status(_("Starting system upgrade. This will take a while."),
+                        UPGRADE_STARTED_ID)
+
+        # reset the splash mode and let the user know we're running
+        Plymouth.set_mode("updates")
+        Plymouth.progress(0)
+        Plymouth.message(_("Starting system upgrade. This will take a while."))
+
+        # disable screen blanking
+        disable_blanking()
+
+        # NOTE: We *assume* that depsolving here will yield the same
+        # transaction as it did during the download, but we aren't doing
+        # anything to *ensure* that; if the metadata changed, or if depsolving
+        # is non-deterministic in some way, we could end up with a different
+        # transaction and then the upgrade will fail due to missing packages.
+        #
+        # One way to *guarantee* that we have the same transaction would be
+        # to save & restore the Transaction object, but there's no documented
+        # way to save a Transaction to disk.
+        #
+        # So far, though, the above assumption seems to hold. So... onward!
+
+        # add the downloaded RPMs to the sack
+        rpms = []
+        for f in os.listdir(self.state.datadir):
+            if f.endswith(".rpm"):
+                rpms.append(os.path.join(self.state.datadir, f))
+        self.base.add_remote_rpms(rpms)
+        # set up the upgrade transaction
+        if self.opts.distro_sync:
+            self.base.distro_sync()
+        else:
+            self.base.upgrade_all()
+
+    def run_clean(self, extcmds):
+        if self.state.datadir:
+            logger.info(_("Cleaning up downloaded data..."))
+            clear_dir(self.state.datadir)
+        with self.state as state:
+            state.download_status = None
+            state.upgrade_status = None
+
+    def run_log(self, extcmds):
+        assert extcmds[0] == 'log'
+        if len(extcmds) == 1:
+            list_logs()
+        else:
+            n = int(extcmds[1])
+            show_log(n)
+
+    # == transaction_*: do stuff after a successful transaction ===============
+
+    def transaction_download(self):
+        # sanity check: we got a kernel, right?
+        downloads = self.cli.base.transaction.install_set
+        if not any(p.name.startswith('kernel') for p in downloads):
+            raise CliError(NO_KERNEL_MSG)
+        # Okay! Write out the state so the upgrade can use it.
+        system_ver = dnf.rpm.detect_releasever(self.base.conf.installroot)
+        with self.state as state:
+            state.download_status = 'complete'
+            state.distro_sync = self.opts.distro_sync
+            state.allow_erasing = self.cli.demands.allow_erasing
+            state.best = self.base.conf.best
+            state.system_releasever = system_ver
+            state.target_releasever = self.base.conf.releasever
+        logger.info(DOWNLOAD_FINISHED_MSG)
+        self.log_status(_("Download finished."),
+                        DOWNLOAD_FINISHED_ID)
+
+    def transaction_upgrade(self):
+        Plymouth.message(_("Upgrade complete! Cleaning up and rebooting..."))
+        self.log_status(_("Upgrade complete! Cleaning up and rebooting..."),
+                        UPGRADE_FINISHED_ID)
+        self.run_clean([])
+        if self.opts.tid[0] == "upgrade":
+            reboot()

--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -1,0 +1,455 @@
+# test_system_upgrade.py - unit tests for system-upgrade plugin
+
+import system_upgrade
+
+from system_upgrade import PLYMOUTH, CliError
+
+import os
+import tempfile
+import shutil
+import gettext
+
+from dnf.callback import (PKG_CLEANUP, PKG_DOWNGRADE, PKG_INSTALL,
+                          PKG_OBSOLETE, PKG_REINSTALL, PKG_REMOVE, PKG_UPGRADE,
+                          PKG_VERIFY, TRANS_POST)
+
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+patch = mock.patch
+
+
+@patch('system_upgrade.call', return_value=0)
+class PlymouthTestCase(unittest.TestCase):
+    def setUp(self):
+        self.ply = system_upgrade.PlymouthOutput()
+        self.msg = "Hello, plymouth."
+        self.msg_args = (PLYMOUTH, "display-message", "--text", self.msg)
+
+    def test_ping(self, call):
+        self.ply.ping()
+        call.assert_called_once_with((PLYMOUTH, "--ping"))
+        self.assertTrue(self.ply.alive)
+
+    def test_ping_when_dead(self, call):
+        call.return_value = 1
+        self.ply.ping()
+        self.assertFalse(self.ply.alive)
+        call.return_value = 0
+        self.ply.ping()
+        self.assertEqual(call.call_count, 2)
+        self.assertTrue(self.ply.alive)
+
+    def test_mode_no_plymouth(self, call):
+        call.side_effect = OSError(2, 'No such file or directory')
+        self.ply.set_mode("updates")
+        self.assertFalse(self.ply.alive)
+
+    def test_message(self, call):
+        self.ply.message(self.msg)
+        call.assert_called_once_with(self.msg_args)
+
+    def test_hide_message(self, call):
+        messages = ("first", "middle", "BONUS", "last")
+        for m in messages:
+            self.ply.message(m)
+
+        def hidem(m):
+            return mock.call((PLYMOUTH, "hide-message", "--text", m))
+
+        def dispm(m):
+            return mock.call((PLYMOUTH, "display-message", "--text", m))
+        m1, m2, m3, m4 = messages
+        call.assert_has_calls([
+            dispm(m1),
+            hidem(m1), dispm(m2),
+            hidem(m2), dispm(m3),
+            hidem(m3), dispm(m4),
+        ])
+
+    def test_message_dupe(self, call):
+        self.ply.message(self.msg)
+        self.ply.message(self.msg)
+        call.assert_called_once_with(self.msg_args)
+
+    def test_message_dead(self, call):
+        call.return_value = 1
+        self.ply.message(self.msg)
+        self.assertFalse(self.ply.alive)
+        self.ply.message("not even gonna bother")
+        call.assert_called_once_with(self.msg_args)
+
+    def test_progress(self, call):
+        self.ply.progress(27)
+        call.assert_called_once_with(
+            (PLYMOUTH, "system-update", "--progress", str(27)))
+
+    def test_mode(self, call):
+        self.ply.set_mode("updates")
+        call.assert_called_once_with((PLYMOUTH, "change-mode", "--updates"))
+
+
+@patch('system_upgrade.call', return_value=0)
+class PlymouthTransactionProgressTestCase(unittest.TestCase):
+    actions = (PKG_CLEANUP, PKG_DOWNGRADE, PKG_INSTALL, PKG_OBSOLETE,
+               PKG_REINSTALL, PKG_REMOVE, PKG_UPGRADE, PKG_VERIFY,
+               TRANS_POST)
+
+    # pylint: disable=protected-access
+    def setUp(self):
+        system_upgrade.Plymouth = system_upgrade.PlymouthOutput()
+        self.display = system_upgrade.PlymouthTransactionProgress()
+        self.pkg = "testpackage"
+
+    def test_display(self, call):
+        for action in self.actions:
+            self.display.progress(self.pkg, action, 0, 100, 1, 1000)
+            msg = self.display._fmt_event(self.pkg, action, 1, 1000)
+            # updating plymouth display means two plymouth calls
+            call.assert_has_calls([
+                mock.call((PLYMOUTH, "system-update", "--progress", "0")),
+                mock.call((PLYMOUTH, "display-message", "--text", msg))
+            ], any_order=True)
+
+    def test_filter_calls(self, call):
+        action = PKG_INSTALL
+        # first display update -> set percentage and text
+        self.display.progress(self.pkg, action, 0, 100, 1, 1000)
+        msg1 = self.display._fmt_event(self.pkg, action, 1, 1000)
+        call.assert_has_calls([
+            mock.call((PLYMOUTH, "system-update", "--progress", "0")),
+            mock.call((PLYMOUTH, "display-message", "--text", msg1)),
+        ])
+
+        # event progress on the same transaction item.
+        # no new calls to plymouth because the percentage and text don't change
+        for te_cur in range(1, 100):
+            self.display.progress(self.pkg, action, te_cur, 100, 1, 1000)
+        call.assert_has_calls([
+            mock.call((PLYMOUTH, "system-update", "--progress", "0")),
+            mock.call((PLYMOUTH, "display-message", "--text", msg1)),
+        ])
+
+        # new item: new message ("[2/1000] ..."), but percentage still 0..
+        self.display.progress(self.pkg, action, 0, 100, 2, 1000)
+        # old message hidden, new message displayed. no new percentage.
+        msg2 = self.display._fmt_event(self.pkg, action, 2, 1000)
+        call.assert_has_calls([
+            mock.call((PLYMOUTH, "system-update", "--progress", "0")),
+            mock.call((PLYMOUTH, "display-message", "--text", msg1)),
+            mock.call((PLYMOUTH, "hide-message", "--text", msg1)),
+            mock.call((PLYMOUTH, "display-message", "--text", msg2)),
+        ])
+
+TESTLANG = "zh_CN"
+TESTLANG_MO = "po/%s.mo" % TESTLANG
+
+
+@unittest.skipUnless(os.path.exists(TESTLANG_MO), "make %s first" %
+                     TESTLANG_MO)
+# @unittest.skip("There is no translation yet to system-upgrade")
+class I18NTestCaseBase(unittest.TestCase):
+    @classmethod
+    @unittest.skip("There is no translation yet to system-upgrade")
+    def setUpClass(cls):
+        cls.localedir = tempfile.mkdtemp(prefix='i18ntest')
+        cls.msgdir = os.path.join(cls.localedir, TESTLANG+"/LC_MESSAGES")
+        cls.msgfile = system_upgrade.TEXTDOMAIN + ".mo"
+        os.makedirs(cls.msgdir)
+        shutil.copy2(TESTLANG_MO, os.path.join(cls.msgdir, cls.msgfile))
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.localedir)
+
+    def setUp(self):
+        self.t = gettext.translation(system_upgrade.TEXTDOMAIN, self.localedir,
+                                     languages=[TESTLANG], fallback=True)
+        self.gettext = self.t.gettext
+
+
+class I18NTestCase(I18NTestCaseBase):
+    @unittest.skip("There is no translation yet to system-upgrade")
+    def test_selftest(self):
+        self.assertIn(self.msgfile, os.listdir(self.msgdir))
+        self.assertIn(TESTLANG, os.listdir(self.localedir))
+        t = gettext.translation(system_upgrade.TEXTDOMAIN, self.localedir,
+                                languages=[TESTLANG], fallback=False)
+        info = t.info()
+        self.assertIn("language", info)
+        self.assertEqual(info["language"], TESTLANG.replace("_", "-"))
+
+    @unittest.skip("There is no translation yet to system-upgrade")
+    def test_fallback(self):
+        msg = "THIS STRING DOES NOT EXIST"
+        trans_msg = self.gettext(msg)
+        self.assertEqual(msg, trans_msg)
+
+    @unittest.skip("There is no translation yet to system-upgrade")
+    def test_translation(self):
+        msg = "the color of the sky"
+        trans_msg = self.gettext(msg)
+        self.assertNotEqual(msg, trans_msg)
+
+
+class StateTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.statedir = tempfile.mkdtemp(prefix="state.test.")
+        cls.StateClass = system_upgrade.State
+        cls.StateClass.statefile = os.path.join(cls.statedir, "state")
+
+    def setUp(self):
+        self.state = self.StateClass()
+
+    def test_set_write_get(self):
+        path = "/some/stupid/path"
+        with self.state:
+            self.state.datadir = path
+        del self.state
+        self.state = self.StateClass()
+        self.assertEqual(self.state.datadir, path)
+
+    def test_clear(self):
+        self.state.clear()
+        del self.state
+        self.state = self.StateClass()
+        self.assertIs(self.state.datadir, None)
+
+    def test_bool_value(self):
+        with self.state:
+            self.state.distro_sync = True
+        del self.state
+        self.state = self.StateClass()
+        self.assertIs(self.state.distro_sync, True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.statedir)
+
+
+class UtilTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='util.test.')
+        self.dirs = ["dir1", "dir2"]
+        self.files = ["file1", "dir2/file2"]
+        for d in self.dirs:
+            os.makedirs(os.path.join(self.tmpdir, d))
+        for f in self.files:
+            with open(os.path.join(self.tmpdir, f), 'wt') as fobj:
+                fobj.write("hi there\n")
+
+    def test_self_test(self):
+        for d in self.dirs:
+            self.assertTrue(os.path.isdir(os.path.join(self.tmpdir, d)))
+        for f in self.files:
+            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, f)))
+
+    def test_clear_dir(self):
+        self.assertTrue(os.path.isdir(self.tmpdir))
+        system_upgrade.clear_dir(self.tmpdir)
+        self.assertTrue(os.path.isdir(self.tmpdir))
+        self.assertEqual(os.listdir(self.tmpdir), [])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+class CommandTestCaseBase(unittest.TestCase):
+    def setUp(self):
+        self.statedir = tempfile.mkdtemp(prefix="command.test.statedir.")
+        self.statefile = os.path.join(self.statedir, "state")
+        self.old_statefile = system_upgrade.State.statefile
+        system_upgrade.State.statefile = self.statefile
+        self.cli = mock.MagicMock()
+        self.command = system_upgrade.SystemUpgradeCommand(cli=self.cli)
+
+    def tearDown(self):
+        shutil.rmtree(self.statedir)
+        system_upgrade.State.statefile = self.old_statefile
+
+
+class CommandTestCase(CommandTestCaseBase):
+    # self-tests for the command test cases
+    def test_state(self):
+        # initial state: no status
+        self.assertEqual(self.command.state.download_status, None)
+        self.assertEqual(self.command.state.upgrade_status, None)
+        self.assertEqual(self.command.state.datadir, None)
+        # check the context stuff works like we expect
+        with self.command.state as state:
+            state.datadir = os.path.join(self.statedir, "datadir")
+            os.makedirs(state.datadir)
+        self.assertTrue(os.path.isdir(self.command.state.datadir))
+
+
+class CleanCommandTestCase(CommandTestCaseBase):
+    def test_configure_clean(self):
+        self.cli.demands.root_user = None
+        self.command.configure_clean([])
+        self.assertTrue(self.cli.demands.root_user)
+
+    def test_run_clean(self):
+        # set up a datadir and pretend like we're ready to upgrade
+        datadir = os.path.join(self.statedir, "datadir")
+        os.makedirs(datadir)
+        fakerpm = os.path.join(datadir, "fake.rpm")
+        with open(fakerpm, "w") as outf:
+            outf.write("hi i am an rpm")
+        with self.command.state as state:
+            state.datadir = datadir
+            state.download_status = "complete"
+            state.upgrade_status = "ready"
+        # make sure the datadir and state info is set up OK
+        self.assertEqual(datadir, self.command.state.datadir)
+        self.assertTrue(os.path.isdir(datadir))
+        self.assertTrue(os.path.exists(fakerpm))
+        self.assertEqual(self.command.state.download_status, "complete")
+        self.assertEqual(self.command.state.upgrade_status, "ready")
+        # run cleanup
+        self.command.run_clean([])
+        # datadir remains, but is empty, and state is cleared
+        self.assertEqual(datadir, self.command.state.datadir)
+        self.assertTrue(os.path.isdir(datadir))
+        self.assertFalse(os.path.exists(fakerpm))
+        self.assertEqual(self.command.state.download_status, None)
+        self.assertEqual(self.command.state.upgrade_status, None)
+
+
+class RebootCheckCommandTestCase(CommandTestCaseBase):
+    def setUp(self):
+        super(RebootCheckCommandTestCase, self).setUp()
+        self.MAGIC_SYMLINK = self.statedir + '/symlink'
+        self.SYSTEMD_FLAG_FILE = self.statedir + '/systemd.flag.file'
+
+    def test_configure_reboot(self):
+        self.cli.demands.root_user = None
+        self.command.configure_reboot()
+        self.assertTrue(self.cli.demands.root_user)
+
+    def check_reboot(self, status='complete', lexists=False, dnfverok=True):
+        with patch('system_upgrade.os.path.lexists') as lexists_func:
+            self.command.state.download_status = status
+            lexists_func.return_value = lexists
+            self.command.check_reboot()
+
+    def test_check_reboot_ok(self):
+        self.check_reboot(status='complete', lexists=False, dnfverok=True)
+
+    def test_check_reboot_no_download(self):
+        with self.assertRaises(CliError):
+            self.check_reboot(status=None, lexists=False, dnfverok=True)
+
+    def test_check_reboot_link_exists(self):
+        with self.assertRaises(CliError):
+            self.check_reboot(status='complete', lexists=True, dnfverok=True)
+
+    def test_run_prepare(self):
+        self.command.state.datadir = '/lol/wut'
+        with patch('system_upgrade.SYSTEMD_FLAG_FILE', self.SYSTEMD_FLAG_FILE):
+            with patch('system_upgrade.MAGIC_SYMLINK', self.MAGIC_SYMLINK):
+                self.command.run_prepare([])
+        self.assertEqual(os.readlink(self.MAGIC_SYMLINK),
+                         self.command.state.datadir)
+        self.assertEqual(self.command.state.upgrade_status, 'ready')
+        releasever = self.command.state.target_releasever
+        with open(self.SYSTEMD_FLAG_FILE) as flag_file:
+            self.assertIn('RELEASEVER=%s\n' % releasever, flag_file.read())
+
+    @patch('system_upgrade.SystemUpgradeCommand.run_prepare')
+    @patch('system_upgrade.SystemUpgradeCommand.log_status')
+    @patch('system_upgrade.reboot')
+    def test_run_reboot(self, reboot, log_status, run_prepare):
+        self.command.opts = mock.MagicMock()
+        self.command.opts.tid = ["reboot"]
+        self.command.run_reboot([])
+        run_prepare.assert_called_once_with([])
+        self.assertEqual(system_upgrade.REBOOT_REQUESTED_ID,
+                         log_status.call_args[0][1])
+        self.assertTrue(reboot.called)
+
+    @patch('system_upgrade.SystemUpgradeCommand.run_prepare')
+    @patch('system_upgrade.SystemUpgradeCommand.log_status')
+    @patch('system_upgrade.reboot')
+    def test_reboot_prepare_only(self, reboot, log_status, run_prepare):
+        self.command.opts = mock.MagicMock()
+        self.command.opts.tid = [None]
+        self.command.run_reboot([])
+        run_prepare.assert_called_once_with([])
+        self.assertFalse(log_status.called)
+        self.assertFalse(reboot.called)
+
+
+class DownloadCommandTestCase(CommandTestCase):
+    def test_configure_download(self):
+        self.command.opts = mock.MagicMock()
+        self.command.opts.tid = "download"
+        self.command.configure()
+        self.assertTrue(self.cli.demands.root_user)
+        self.assertTrue(self.cli.demands.resolving)
+        self.assertTrue(self.cli.demands.sack_activation)
+        self.assertTrue(self.cli.demands.available_repos)
+        for repo in self.command.base.repos.values():
+            self.assertEqual(repo.pkgdir, self.command.opts.datadir)
+
+    def test_transaction_download(self):
+        pkg = mock.MagicMock()
+        pkg.name = "kernel"
+        self.cli.base.transaction.install_set = [pkg]
+        self.command.opts = mock.MagicMock()
+        self.command.opts.distro_sync = "distro_sync"
+        self.cli.demands.allow_erasing = "allow_erasing"
+        self.command.base.conf.best = "best"
+        self.command.base.conf.installroot = "/"
+        self.command.base.conf.releasever = "35"
+        self.command.transaction_download()
+        with system_upgrade.State() as state:
+            self.assertEqual(state.download_status, "complete")
+            self.assertEqual(state.distro_sync, "distro_sync")
+            self.assertEqual(state.allow_erasing, "allow_erasing")
+            self.assertEqual(state.best, "best")
+
+    def test_transaction_download_no_kernel(self):
+        self.cli.base.transaction.install_set = []
+        with self.assertRaises(CliError):
+            self.command.transaction_download()
+
+
+class UpgradeCommandTestCase(CommandTestCase):
+    def test_configure_upgrade(self):
+        # write state like download would have
+        with self.command.state as state:
+            state.download_status = "complete"
+            state.distro_sync = True
+            state.allow_erasing = True
+            state.best = True
+        # okay, now configure upgrade
+        self.command.opts = mock.MagicMock()
+        self.command.opts.tid = "upgrade"
+        self.command.configure()
+        # did we reset the depsolving flags?
+        self.assertTrue(self.command.opts.distro_sync)
+        self.assertTrue(self.cli.demands.allow_erasing)
+        self.assertTrue(self.command.base.conf.best)
+        # are we on autopilot?
+        self.assertTrue(self.command.base.conf.assumeyes)
+        self.assertTrue(self.cli.demands.cacheonly)
+
+
+class LogCommandTestCase(CommandTestCase):
+    def test_configure_log(self):
+        self.command.opts = mock.MagicMock()
+        self.command.opts.tid = "log"
+        self.command.configure()
+
+    def test_run_log_list(self):
+        with patch('system_upgrade.list_logs') as list_logs:
+            self.command.run_log(["log"])
+        list_logs.assert_called_once_with()
+
+    def test_run_log_prev(self):
+        with patch('system_upgrade.show_log') as show_log:
+            self.command.run_log(["log", "-2"])
+        show_log.assert_called_once_with(-2)


### PR DESCRIPTION
This PR is identical to #66 (and indeed has the same commits), except that the commit altering the spec file has been rediffed against the current master and does not do more than add the system upgrade subpackage.

This should be acceptable for inclusion provided that everything else in #66 was fine.