### PR TITLE
Add repo name for local repo

### DIFF
--- a/plugins/local.py
+++ b/plugins/local.py
@@ -101,6 +101,7 @@ class Local(dnf.Plugin):
 
         local_repo = dnf.repo.Repo("_dnf_local", self.base.conf)
         local_repo.baseurl = "file://{}".format(self.main["repodir"])
+        local_repo.name = "_dnf_local"
         self.base.repos.add(local_repo)
 
     def transaction(self):


### PR DESCRIPTION
It negatively interact with repolist

Traceback (most recent call last):
File "/usr/bin/dnf", line 58, in
main.user_main(sys.argv[1:], exit_code=True)
File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 175, in user_main
errcode = main(args)
File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 61, in main
return _main(base, args)
File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 99, in _main
return cli_run(cli, base)
File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 115, in cli_run
cli.run()
File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 936, in run
return self.command.run()
File "/usr/lib/python3.5/site-packages/dnf/cli/commands/repolist.py", line 250, in run
if nm_len < exact_width(rname):
File "/usr/lib/python3.5/site-packages/dnf/i18n.py", line 176, in exact_width
return sum(_exact_width_char(c) for c in msg)
TypeError: 'NoneType' object is not iterable