### PR TITLE
setup SideCI to ignore some PEP8 violations

### DIFF
--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,3 @@
+linter:
+  flake8:
+    version: 3

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[flake8]
+# C0111: docstrings
+# I0011: locally disabled warnings
+# R0801: similar lines
+# R0904: too many public methods
+# R0911: too many return statements
+# R0912: too many branches
+# R0913: too many arguments
+# R0903: too few public methods
+# W0141: used builtin 'map' function
+# W0142: used star magic
+# W0212: access to a protected member
+ignore = C0111,I0011,R0801,R0904,R0911,R0912,R0913,R0903,W0141,W0142,W0212
+exclude = .git,__pycache__
+max-line-length = 100


### PR DESCRIPTION
unfortunately tox.ini and sideci.yml has to be in the root directory.
SideCI doesn't currently support custom path to flake8 configuration file.