### PR TITLE
Fix builds in doc-man target

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import codecs
 import sys
 import os
 import os.path
@@ -57,11 +58,10 @@ copyright = u'2014, Igor Gnatenko, Licensed under GPLv2+'
 
 def version_readout():
     fn = os.path.join(_dirname, '../dnf-plugins-extras.spec')
-    with open(fn) as f:
-        lines = f.readlines()
-    for line in lines:
-        if line.startswith('Version:'):
-            return line.split(':')[1].strip()
+    with codecs.open(fn, "r", "utf-8") as f:
+        for line in f.readlines():
+            if line.startswith('Version:'):
+                return line.split(':')[1].strip()
 
 version = '%s' % version_readout()
 # The full version, including alpha/beta/rc tags.


### PR DESCRIPTION
Trivial back-port of https://github.com/fedora-copr/dnf-plugins-core/commit/b09f4f02dc3082e1893411e0bd1dcb20881c86d2

```
Scanning dependencies of target doc-man
make[3]: Leaving directory '/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2'
make -f doc/CMakeFiles/doc-man.dir/build.make doc/CMakeFiles/doc-man.dir/build
make[3]: Entering directory '/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2'
[100%] Building manpage documentation
cd /root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2/doc && PYTHONPATH=/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12 sphinx-build -b man /root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/doc /root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2/doc
Running Sphinx v1.4.8

Encoding error:
'ascii' codec can't decode byte 0xe3 in position 4102: ordinal not in range(128)
The full traceback has been saved in /var/tmp/sphinx-err-3y0aczcd.log, if you want to report the issue to the developers.
doc/CMakeFiles/doc-man.dir/build.make:60: recipe for target 'doc/CMakeFiles/doc-man' failed
make[3]: *** [doc/CMakeFiles/doc-man] Error 1
make[3]: Leaving directory '/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2'
CMakeFiles/Makefile2:90: recipe for target 'doc/CMakeFiles/doc-man.dir/all' failed
make[2]: *** [doc/CMakeFiles/doc-man.dir/all] Error 2
make[2]: Leaving directory '/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2'
CMakeFiles/Makefile2:97: recipe for target 'doc/CMakeFiles/doc-man.dir/rule' failed
make[1]: *** [doc/CMakeFiles/doc-man.dir/rule] Error 2
make[1]: Leaving directory '/root/rpmbuild/BUILD/dnf-plugins-extras-0.0.12/python2'
Makefile:154: recipe for target 'doc-man' failed
make: *** [doc-man] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.WLMEx6 (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.WLMEx6 (%build)
```

Everything compiles file with the patch in place.