### PR TITLE
Repoclosure exit with 1 if unsatisfied dependencies

### DIFF
--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -66,6 +66,9 @@ class RepoClosureCommand(dnf.cli.Command):
             print("  unresolved deps:")
             for dep in unresolved[pkg]:
                 print("    {}".format(dep))
+        if len(unresolved) > 0:
+            msg = _("Repoclosure ended with unresloved dependencies.")
+            raise dnf.exceptions.Error(msg)
 
     def _get_unresolved(self, arch=None):
         unresolved = {}

--- a/tests/test_repoclosure.py
+++ b/tests/test_repoclosure.py
@@ -47,7 +47,12 @@ class TestRepoClosureFunctions(support.TestCase):
         self.cmd.base.add_remote_rpms([os.path.join(self.path,
             "noarch/foo-4-6.noarch.rpm")])
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
-            support.command_run(self.cmd, args)
+            with self.assertRaises(dnf.exceptions.Error) as context:
+                support.command_run(self.cmd, args)
+
+            self.assertEqual(context.exception.value,
+                             "Repoclosure ended with unresloved dependencies.")
+
             expected_out = ["package: foo-4-6.noarch from @commandline",
                             "  unresolved deps:",
                             "    bar = 4-6"]
@@ -62,7 +67,12 @@ class TestRepoClosureFunctions(support.TestCase):
         self.cmd.base.add_remote_rpms([os.path.join(self.path,
             "noarch/foo-4-6.noarch.rpm")])
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
-            support.command_run(self.cmd, args)
+            with self.assertRaises(dnf.exceptions.Error) as context:
+                support.command_run(self.cmd, args)
+
+            self.assertEqual(context.exception.value,
+                             "Repoclosure ended with unresloved dependencies.")
+
             expected_out = ["package: foo-4-6.noarch from @commandline",
                             "  unresolved deps:",
                             "    bar = 4-6"]
@@ -77,7 +87,12 @@ class TestRepoClosureFunctions(support.TestCase):
         self.cmd.base.add_remote_rpms([os.path.join(self.path,
             "noarch/foo-4-6.noarch.rpm")])
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
-            support.command_run(self.cmd, args)
+            with self.assertRaises(dnf.exceptions.Error) as context:
+                support.command_run(self.cmd, args)
+
+            self.assertEqual(context.exception.value,
+                             "Repoclosure ended with unresloved dependencies.")
+
             expected_out = ["package: foo-4-6.noarch from @commandline",
                             "  unresolved deps:",
                             "    bar = 4-6"]


### PR DESCRIPTION
If dnf repoclosure finds unsatisfied dependencies in a repo then it will exit with 1.
For better usage with scripts and yum repoclosure compatibility.