### PR TITLE
dnf-system-upgrade.service: make sure systemd waits for us to finish

### DIFF
--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -1,14 +1,16 @@
 [Unit]
-Description=System Upgrade
+Description=System Upgrade using DNF
 ConditionPathExists=/system-update/.dnf-system-upgrade
 Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 
 DefaultDependencies=no
 Requires=sysinit.target
 After=sysinit.target systemd-journald.socket
-Before=shutdown.target
+Before=shutdown.target system-update.target
 
 [Service]
+# We are done when the script exits, not before
+Type=oneshot
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console
 # This won't exist after we delete the symlink; don't consider that an error.


### PR DESCRIPTION
In f0bef8e9193881f388 I forgot to add the ordering dependency
with system-update.target. This was "wrong", but did not matter until
system-update-cleanup.service which is started after system-update.target
was added in systemd-233. Fix this omission.

(This is the same bug as
https://bugzilla.redhat.com/show_bug.cgi?id=1430920. It wasn't reported
so far, but dnf-system-upgrade.service is subject to the same race as
pk-offline-update.service.)

Also: add " using DNF" to Description, so it's clearer which upgrade
mechanism is started when multiple are installed.