### PR TITLE
Add warn to ensure that system is fully upgraded (RhBug:1225442)

### DIFF
--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -36,7 +36,9 @@ Synopsis
 
 ``dnf system-upgrade clean``
 
-``dnf system-upgrade log [NUMBER]``
+``dnf system-upgrade log``
+
+``dnf system-upgrade log --number <number>``
 
 
 -----------
@@ -79,10 +81,8 @@ Options
     if they are older than what is currently installed. This is the opposite of
     ``--distro-sync``. If both are specified, the last option will be used.
 
-``--datadir=DIRECTORY``
-    Save downloaded packages to ``DIRECTORY``. DIRECTORY must already exist.
-    This directory ``must`` be mounted automatically by the system or the
-    upgrade will not work. The default is ``/var/lib/dnf/system-update``.
+``--number``
+    Applied with ``log`` subcommand will show log speciffied by the number
 
 -----
 Notes
@@ -120,7 +120,7 @@ Typical upgrade usage
 Show logs from last upgrade attempt
 -----------------------------------
 
-``dnf system-upgrade log -1``
+``dnf system-upgrade log --number=-1``
 
 --------------
 Reporting Bugs

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -24,8 +24,8 @@ Description
 -----------
 
 ``dnf system-upgrade`` can be used to upgrade a Fedora system to a new major
-release. It replaces fedup (the old Fedora Upgrade tool).
-
+release. It replaces fedup (the old Fedora Upgrade tool). Before you proceed ensure that your system
+is fully upgraded (``dnf --refresh upgrade``).
 --------
 Synopsis
 --------
@@ -110,6 +110,8 @@ Examples
 
 Typical upgrade usage
 ---------------------
+
+``dnf --refresh upgrade``
 
 ``dnf system-upgrade download --releasever 26``
 

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -38,7 +38,7 @@ Synopsis
 
 ``dnf system-upgrade log``
 
-``dnf system-upgrade log --number <number>``
+``dnf system-upgrade log --number=<number>``
 
 
 -----------
@@ -60,7 +60,7 @@ Subcommands
     Used to see a list of boots during which an upgrade was attempted, or show
     the logs from an upgrade attempt. The logs for one of the boots can be shown
     by specifying one of the numbers in the first column. Negative numbers can
-    be used to number the boots from last to first. For example, ``log -1`` can
+    be used to number the boots from last to first. For example, ``log --number=-1`` can
     be used to see the logs for the last upgrade attempt.
 
 -------
@@ -137,7 +137,7 @@ For more info on filing bugs, see the Fedora Project wiki:
   https://fedoraproject.org/wiki/Bugs_and_feature_requests
 
 Please include ``/var/log/dnf.log`` and the output of
-``dnf system-upgrade log -1`` (if applicable) in your bug reports.
+``dnf system-upgrade log --number=-1`` (if applicable) in your bug reports.
 
 Problems with dependency solving during download are best reported to the
 maintainers of the package(s) with the dependency problems.

--- a/plugins/kickstart.py
+++ b/plugins/kickstart.py
@@ -19,10 +19,11 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from dnfpluginsextras import _, logger
 
-import dnf.cli
 import pykickstart.parser
+
+from dnfpluginsextras import _, logger
+import dnf.cli
 
 
 def parse_kickstart_packages(path):

--- a/plugins/rpm_conf.py
+++ b/plugins/rpm_conf.py
@@ -19,10 +19,11 @@
 
 import sys
 import errno
-from dnfpluginsextras import _, logger
 
-import dnf
 from rpmconf import rpmconf
+
+from dnfpluginsextras import _, logger
+import dnf
 
 
 class Rpmconf(dnf.Plugin):

--- a/plugins/snapper.py
+++ b/plugins/snapper.py
@@ -19,12 +19,10 @@
 #
 
 from dbus import SystemBus, Interface, DBusException
-import dnf
-import dnfpluginsextras
 import sys
 
-_ = dnfpluginsextras._
-logger = dnfpluginsextras.logger
+from dnfpluginsextras import _, logger
+import dnf
 
 
 class Snapper(dnf.Plugin):

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -345,6 +345,12 @@ class SystemUpgradeCommand(dnf.cli.Command):
     # == configure_*: set up action-specific demands ==========================
 
     def configure_download(self, *args):
+        if self.base._promptWanted():
+            msg = _('Before you continue ensure that your system is fully upgraded by running '
+                    '"dnf --refresh upgrade". Do you want to continue')
+            if self.base.conf.assumeno or not self.base.output.userconfirm(
+                    msg='{} [y/N]: '.format(msg), defaultyes_msg='{} [Y/n]: '.format(msg)):
+                raise dnf.cli.CliError(_("Operation aborted."))
         self.cli.demands.root_user = True
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -32,23 +32,10 @@ from dnf.cli import CliError
 
 import uuid
 
-import logging
 from systemd import journal
 
 from distutils.version import StrictVersion
-
-try:
-    from dnf.i18n import translation
-except ImportError:
-    # adapted from dnf-1.1.4's dnf.i18n.translation()
-    def translation(name):
-        def ucd_wrapper(fnc):
-            return lambda *w: dnf.i18n.ucd(fnc(*w))
-        t = dnf.pycomp.gettext.translation(name, fallback=True)
-        return (ucd_wrapper(f) for f in dnf.pycomp.gettext_setup(t))
-
-TEXTDOMAIN = 'dnf-plugin-system-upgrade'    # NOTE: must match Makefile
-_, P_ = translation(TEXTDOMAIN)
+from dnfpluginsextras import _, logger
 
 # Translators: This string is only used in unit tests.
 _("the color of the sky")
@@ -59,8 +46,6 @@ UPGRADE_STARTED_ID = uuid.UUID('3e0a5636d16b4ca4bbe5321d06c6aa62')
 UPGRADE_FINISHED_ID = uuid.UUID('8cec00a1566f4d3594f116450395f06c')
 
 ID_TO_IDENTIFY_BOOTS = UPGRADE_STARTED_ID
-
-logger = logging.getLogger("dnf.plugin")
 
 DNFVERSION = StrictVersion(dnf.const.VERSION)
 

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -20,22 +20,18 @@
 """system_upgrade.py - DNF plugin to handle major-version system upgrades."""
 
 from __future__ import unicode_literals
-
+from distutils.version import StrictVersion
+from subprocess import call, check_call
 import os
 import json
-
-from subprocess import call, check_call
-
-import dnf
-import dnf.cli
-from dnf.cli import CliError
-
 import uuid
 
 from systemd import journal
 
-from distutils.version import StrictVersion
+from dnf.cli import CliError
 from dnfpluginsextras import _, logger
+import dnf
+import dnf.cli
 
 # Translators: This string is only used in unit tests.
 _("the color of the sky")

--- a/plugins/torproxy.py
+++ b/plugins/torproxy.py
@@ -18,15 +18,16 @@
 # Red Hat, Inc.
 #
 
-import dnf
-import dnf.plugin
-import dnfpluginsextras
-import pycurl
 import json
 import io
 import iniparse.compat as ini
 
-from dnfpluginscore import _
+import pycurl
+
+from dnfpluginsextras import _, logger
+import dnf
+import dnf.plugin
+
 
 MSG = _('Disabling torproxy plugin: cannot connect to the Tor network')
 
@@ -38,7 +39,6 @@ class TorProxy(dnf.Plugin):
     def __init__(self, base, cli):
         super(TorProxy, self).__init__(base, cli)
         self.base = base
-        self.logger = dnfpluginsextras.logger
 
     def _check_tor_working(self):
 
@@ -60,7 +60,7 @@ class TorProxy(dnf.Plugin):
             result = json.loads(buf.getvalue().decode("ascii"))['IsTor']
         # TODO fix me, need to have a better exception filter
         except Exception as e:
-            self.logger.error(e)
+            logger.error(e)
             result = False
 
         return result
@@ -91,6 +91,6 @@ class TorProxy(dnf.Plugin):
                     repo.proxy_username = 'dnf_' + name
                     repo.proxy_password = 'dnf_' + name
         else:
-            self.logger.error(MSG)
+            logger.error(MSG)
             if conf.getboolean('main', 'strict'):
                 raise dnf.exceptions.Error

--- a/plugins/tracer.py
+++ b/plugins/tracer.py
@@ -21,16 +21,15 @@
 #
 
 from __future__ import absolute_import
-
 import time
 import traceback
-import dnf.cli
-import dnf.util
-import dnfpluginsextras
+
 from tracer import Query, Package
 from tracer.views.default import DefaultView
 
-_ = dnfpluginsextras._
+from dnfpluginsextras import _
+import dnf.cli
+import dnf.util
 
 
 class Tracer(dnf.Plugin):


### PR DESCRIPTION
It should help user to realize that there could be an issue when system is not
fully upgraded.

The patch also enhance the documentation.

https://bugzilla.redhat.com/show_bug.cgi?id=1225442

Requires: https://github.com/rpm-software-management/dnf/pull/841