### PR TITLE
Add demands.fresh_metadata=false for syste_upgrade

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -364,6 +364,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
     def configure_upgrade(self):
         # same as the download, but offline and non-interactive. so...
         self.cli.demands.root_user = True
+        self.cli.demands.fresh_metadata = False
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True
         self.cli.demands.sack_activation = True

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -330,10 +330,13 @@ class SystemUpgradeCommand(dnf.cli.Command):
             subfunc()
 
     # == pre_configure_*: set up action-specific demands ==========================
+    def pre_configure_download(self):
+        self.base.conf.cachedir = DEFAULT_DATADIR
 
     def pre_configure_upgrade(self):
         if self.state.enable_disable_repos:
             self.opts.repos_ed = self.state.enable_disable_repos
+        self.base.conf.cachedir = DEFAULT_DATADIR
 
     # == configure_*: set up action-specific demands ==========================
 

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -348,6 +348,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True
         self.cli.demands.sack_activation = True
+        self.cli.demands.freshest_metadata = True
         # We want to do the depsolve / download / transaction-test, but *not*
         # run the actual RPM transaction to install the downloaded packages.
         # Setting the "test" flag makes the RPM transaction a test transaction,


### PR DESCRIPTION
It should prevent upgrading expired metadata during reboot.