### PR TITLE
Do not raise traceback for reboot calls

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 from distutils.version import StrictVersion
-from subprocess import call, check_call, Popen
+from subprocess import call, Popen
 import json
 import os
 import uuid
@@ -63,7 +63,7 @@ CANT_RESET_RELEASEVER = _(
 
 
 def reboot():
-    check_call(["systemctl", "reboot"])
+    Popen(["systemctl", "reboot"])
 
 
 # DNF-FIXME: dnf.util.clear_dir() doesn't delete regular files :/


### PR DESCRIPTION
It should allow to finish dnf while reboot call is performed.

https://bugzilla.redhat.com/show_bug.cgi?id=1499284