### PR TITLE
Releasever for system-upgrade is now set in pre_configuration()

### DIFF
--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=System Upgrade using DNF
-ConditionPathExists=/system-update/.dnf-system-upgrade
+ConditionPathExists=/system-update
 Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 
 DefaultDependencies=no
@@ -13,11 +13,7 @@ Before=shutdown.target system-update.target
 Type=oneshot
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console
-# This won't exist after we delete the symlink; don't consider that an error.
-EnvironmentFile=-/system-update/.dnf-system-upgrade
-# We need the --releasever junk because there's no way for DNF plugins to
-# change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
-ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
+ExecStart=/usr/bin/dnf system-upgrade upgrade
 # Remove the symlink if it's still there, to protect against reboot loops.
 ExecStopPost=/usr/bin/rm -fv /system-update
 # If anything goes wrong, reboot back to the normal system.

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -48,7 +48,6 @@ DNFVERSION = StrictVersion(dnf.const.VERSION)
 PLYMOUTH = '/usr/bin/plymouth'
 DEFAULT_DATADIR = '/var/lib/dnf/system-upgrade'
 MAGIC_SYMLINK = '/system-update'
-SYSTEMD_FLAG_FILE = os.path.join(MAGIC_SYMLINK, '.dnf-system-upgrade')
 
 NO_KERNEL_MSG = _(
     "No new kernel packages were found.")
@@ -337,6 +336,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
         if self.state.enable_disable_repos:
             self.opts.repos_ed = self.state.enable_disable_repos
         self.base.conf.cachedir = DEFAULT_DATADIR
+        self.base.conf.releasever = self.state.target_releasever
 
     # == configure_*: set up action-specific demands ==========================
 
@@ -420,9 +420,6 @@ class SystemUpgradeCommand(dnf.cli.Command):
     def run_prepare(self):
         # make the magic symlink
         os.symlink(DEFAULT_DATADIR, MAGIC_SYMLINK)
-        # write releasever into the flag file so it can be read by systemd
-        with open(SYSTEMD_FLAG_FILE, 'w') as flagfile:
-            flagfile.write("RELEASEVER=%s\n" % self.state.target_releasever)
         # set upgrade_status so that the upgrade can run
         with self.state as state:
             state.upgrade_status = 'ready'

--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -288,7 +288,6 @@ class RebootCheckCommandTestCase(CommandTestCaseBase):
     def setUp(self):
         super(RebootCheckCommandTestCase, self).setUp()
         self.MAGIC_SYMLINK = self.statedir + '/symlink'
-        self.SYSTEMD_FLAG_FILE = self.statedir + '/systemd.flag.file'
 
     def test_configure_reboot(self):
         self.cli.demands.root_user = None
@@ -313,14 +312,10 @@ class RebootCheckCommandTestCase(CommandTestCaseBase):
             self.check_reboot(status='complete', lexists=True, dnfverok=True)
 
     def test_run_prepare(self):
-        with patch('system_upgrade.SYSTEMD_FLAG_FILE', self.SYSTEMD_FLAG_FILE):
-            with patch('system_upgrade.MAGIC_SYMLINK', self.MAGIC_SYMLINK):
-                self.command.run_prepare()
+        with patch('system_upgrade.MAGIC_SYMLINK', self.MAGIC_SYMLINK):
+            self.command.run_prepare()
         self.assertEqual(os.readlink(self.MAGIC_SYMLINK), '/var/lib/dnf/system-upgrade')
         self.assertEqual(self.command.state.upgrade_status, 'ready')
-        releasever = self.command.state.target_releasever
-        with open(self.SYSTEMD_FLAG_FILE) as flag_file:
-            self.assertIn('RELEASEVER=%s\n' % releasever, flag_file.read())
 
     @patch('system_upgrade.SystemUpgradeCommand.run_prepare')
     @patch('system_upgrade.SystemUpgradeCommand.log_status')


### PR DESCRIPTION
Also removing now empty file /system-update/.dnf-system-upgrade

originally was this PR https://github.com/rpm-software-management/dnf-plugins-extras/pull/108 which I accidentally closed.