### PR TITLE
use --cacheonly in dnf-system-upgrade.service

### DIFF
--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -17,7 +17,7 @@ StandardOutput=journal+console
 EnvironmentFile=-/system-update/.dnf-system-upgrade
 # We need the --releasever junk because there's no way for DNF plugins to
 # change $releasever - see https://bugzilla.redhat.com/show_bug.cgi?id=1212341
-ExecStart=/usr/bin/dnf --releasever=${RELEASEVER} system-upgrade upgrade
+ExecStart=/usr/bin/dnf --cacheonly --releasever=${RELEASEVER} system-upgrade upgrade
 # Remove the symlink if it's still there, to protect against reboot loops.
 ExecStopPost=/usr/bin/rm -fv /system-update
 # If anything goes wrong, reboot back to the normal system.


### PR DESCRIPTION
I tried to upgrade to Fedora 27 today and ran into problems. My investigation showed that dnf tried to update its caches after the reboot, and of course failed because there's no network at this point. Since dnf needs to operate from the cache anyway during system-upgrade, I tried adding this flag and then it worked. Since updating the cache during system-update really never makes sense, I figured it's probably a good idea in general to add this flag. 

Note that I did run `dnf update` before starting the whole system-upgrade procedure.