### PR TITLE
Remove unnecessary demands

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -367,11 +367,9 @@ class SystemUpgradeCommand(dnf.cli.Command):
     def configure_upgrade(self):
         # same as the download, but offline and non-interactive. so...
         self.cli.demands.root_user = True
-        self.cli.demands.fresh_metadata = False
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True
         self.cli.demands.sack_activation = True
-        self.cli.demands.cacheonly = True
         # use the saved value for --allowerasing, etc.
         self.opts.distro_sync = self.state.distro_sync
         self.cli.demands.allow_erasing = self.state.allow_erasing


### PR DESCRIPTION
Demand cacheonly is there twice, therefore it can be removed.

Demand cacheonly is stronger than fresh_metadata, therefore it can be also
removed.