### PR TITLE
do not remove /system-update symlink not created by dnf (RhB 1519543)

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -348,6 +348,7 @@ PYTHONPATH="%{buildroot}%{python3_sitelib}:%{buildroot}%{python3_sitelib}/dnf-pl
 
 %files -n python2-dnf-plugin-system-upgrade
 %{_unitdir}/dnf-system-upgrade.service
+%{_unitdir}/dnf-system-upgrade-cleanup.service
 %{_unitdir}/system-update.target.wants/dnf-system-upgrade.service
 %{python2_sitelib}/dnf-plugins/system_upgrade.*
 %{_mandir}/man8/dnf.plugin.system-upgrade.*
@@ -355,6 +356,7 @@ PYTHONPATH="%{buildroot}%{python3_sitelib}:%{buildroot}%{python3_sitelib}/dnf-pl
 %if %{with python3}
 %files -n python3-dnf-plugin-system-upgrade
 %{_unitdir}/dnf-system-upgrade.service
+%{_unitdir}/dnf-system-upgrade-cleanup.service
 %{_unitdir}/system-update.target.wants/dnf-system-upgrade.service
 %{python3_sitelib}/dnf-plugins/system_upgrade.py
 %{python3_sitelib}/dnf-plugins/__pycache__/system_upgrade.*

--- a/etc/systemd/CMakeLists.txt
+++ b/etc/systemd/CMakeLists.txt
@@ -1,1 +1,1 @@
-INSTALL (FILES dnf-system-upgrade.service DESTINATION ${SYSTEMD_DIR})
+INSTALL (FILES "dnf-system-upgrade.service" "dnf-system-upgrade-cleanup.service" DESTINATION ${SYSTEMD_DIR})

--- a/etc/systemd/dnf-system-upgrade-cleanup.service
+++ b/etc/systemd/dnf-system-upgrade-cleanup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=System Upgrade using DNF failed
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+# Remove the symlink if it's still there, to protect against reboot loops.
+ExecStart=/usr/bin/rm -fv /system-update
+# If anything goes wrong, reboot back to the normal system.
+ExecStart=/usr/bin/systemctl --no-block reboot
+

--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -7,6 +7,7 @@ DefaultDependencies=no
 Requires=sysinit.target
 After=sysinit.target systemd-journald.socket
 Before=shutdown.target system-update.target
+OnFailure=dnf-system-upgrade-cleanup.service
 
 [Service]
 # We are done when the script exits, not before
@@ -14,10 +15,6 @@ Type=oneshot
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console
 ExecStart=/usr/bin/dnf system-upgrade upgrade
-# Remove the symlink if it's still there, to protect against reboot loops.
-ExecStopPost=/usr/bin/rm -fv /system-update
-# If anything goes wrong, reboot back to the normal system.
-FailureAction=reboot
 
 [Install]
 WantedBy=system-update.target


### PR DESCRIPTION
If offline update was initiated by another tool, do not remove
/system-update symlink.

https://bugzilla.redhat.com/show_bug.cgi?id=1519543