### PR TITLE
system-upgrade cachedir configurable (RhBug:1513823)

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -1,4 +1,4 @@
-%{!?dnf_lowest_compatible: %global dnf_lowest_compatible 2.7.1}
+%{!?dnf_lowest_compatible: %global dnf_lowest_compatible 2.8.9}
 %global dnf_plugins_extra_obsolete 2.0.0
 
 %if 0%{?rhel} && 0%{?rhel} <= 7
@@ -8,7 +8,7 @@
 %endif
 
 Name:           dnf-plugins-extras
-Version:        2.0.5
+Version:        2.0.6
 Release:        1%{?dist}
 Summary:        Extras Plugins for DNF
 License:        GPLv2+

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -72,8 +72,9 @@ Options
     repos. Usually a number, or ``rawhide``.
 
 ``--downloaddir=<path>``
-    Directory where downloaded packages are stored. Default location is
-    /var/lib/dnf/system-upgrade
+    Redirect download of packages to provided ``<path>``. By default, packages
+    are downloaded into (per repository created) subdirectories of
+    /var/lib/dnf/system-upgrade.
 
 ``--distro-sync``
     Behave like ``dnf distro-sync``: always install packages from the new

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -71,6 +71,10 @@ Options
     REQUIRED. The version to upgrade to. Sets ``$releasever`` in all enabled
     repos. Usually a number, or ``rawhide``.
 
+``--downloaddir=<path>``
+    Directory where downloaded packages are stored. Default location is
+    /var/lib/dnf/system-upgrade
+
 ``--distro-sync``
     Behave like ``dnf distro-sync``: always install packages from the new
     release, even if they are older than the currently-installed version. This

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -142,6 +142,7 @@ class State(object):
         return property(getprop, setprop)
 
     download_status = _prop("download_status")
+    destdir = _prop("destdir")
     target_releasever = _prop("target_releasever")
     system_releasever = _prop("system_releasever")
     gpgcheck = _prop("gpgcheck")
@@ -328,15 +329,28 @@ class SystemUpgradeCommand(dnf.cli.Command):
         if callable(subfunc):
             subfunc()
 
+    def _set_cachedir(self):
+        # set download directories from json state file
+        self.base.conf.cachedir = DEFAULT_DATADIR
+        self.base.conf.destdir = self.state.destdir if self.state.destdir else None
+
     # == pre_configure_*: set up action-specific demands ==========================
     def pre_configure_download(self):
+        # only download subcommand accepts --destdir command line option
         self.base.conf.cachedir = DEFAULT_DATADIR
+        self.base.conf.destdir = self.opts.destdir if self.opts.destdir else None
+
+    def pre_configure_reboot(self):
+        self._set_cachedir()
 
     def pre_configure_upgrade(self):
+        self._set_cachedir()
         if self.state.enable_disable_repos:
             self.opts.repos_ed = self.state.enable_disable_repos
-        self.base.conf.cachedir = DEFAULT_DATADIR
         self.base.conf.releasever = self.state.target_releasever
+
+    def pre_configure_clean(self):
+        self._set_cachedir()
 
     # == configure_*: set up action-specific demands ==========================
 
@@ -346,7 +360,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
                     '"dnf --refresh upgrade". Do you want to continue')
             if self.base.conf.assumeno or not self.base.output.userconfirm(
                     msg='{} [y/N]: '.format(msg), defaultyes_msg='{} [Y/n]: '.format(msg)):
-                raise dnf.cli.CliError(_("Operation aborted."))
+                raise CliError(_("Operation aborted."))
         self.cli.demands.root_user = True
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True
@@ -393,13 +407,16 @@ class SystemUpgradeCommand(dnf.cli.Command):
 
     def check_download(self):
         checkReleaseVer(self.base.conf, target=self.opts.releasever)
-        dnf.util.ensure_dir(DEFAULT_DATADIR)
+        dnf.util.ensure_dir(self.base.conf.cachedir)
+        if self.base.conf.destdir:
+            dnf.util.ensure_dir(self.base.conf.destdir)
 
     def check_reboot(self):
         if not self.state.download_status == 'complete':
             raise CliError(_("system is not ready for upgrade"))
         if os.path.lexists(MAGIC_SYMLINK):
             raise CliError(_("upgrade is already scheduled"))
+        dnf.util.ensure_dir(DEFAULT_DATADIR)
         # FUTURE: checkRPMDBStatus(self.state.download_transaction_id)
 
     def check_upgrade(self):
@@ -416,9 +433,6 @@ class SystemUpgradeCommand(dnf.cli.Command):
                 _("use 'dnf system-upgrade reboot' to begin the upgrade"))
 
     # == run_*: run the action/prep the transaction ===========================
-
-    def run_help(self):
-        self.parser.print_help()
 
     def run_prepare(self):
         # make the magic symlink
@@ -448,6 +462,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
             state.download_status = 'downloading'
             state.target_releasever = self.base.conf.releasever
             state.exclude = self.base.conf.exclude
+            state.destdir = self.base.conf.destdir
 
     def run_upgrade(self):
         # change the upgrade status (so we can detect crashed upgrades later)
@@ -495,10 +510,13 @@ class SystemUpgradeCommand(dnf.cli.Command):
 
     def run_clean(self):
         logger.info(_("Cleaning up downloaded data..."))
-        clear_dir(DEFAULT_DATADIR)
+        clear_dir(self.base.conf.cachedir)
+        if self.base.conf.destdir:
+            clear_dir(self.base.conf.destdir)
         with self.state as state:
             state.download_status = None
             state.upgrade_status = None
+            state.destdir = None
             state.install_packages = {}
 
     def run_log(self):
@@ -527,6 +545,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
             state.target_releasever = self.base.conf.releasever
             state.install_packages = install_packages
             state.enable_disable_repos = self.opts.repos_ed
+            state.destdir = self.base.conf.destdir
         logger.info(DOWNLOAD_FINISHED_MSG)
         self.log_status(_("Download finished."),
                         DOWNLOAD_FINISHED_ID)


### PR DESCRIPTION
Makes it possible to change default download dir for the system-upgrade
command using --downloaddir argument.
It can be useful for systems with limited space on the root
filesystem.

Requires https://github.com/rpm-software-management/dnf/pull/1014

https://bugzilla.redhat.com/show_bug.cgi?id=1513823