### PR TITLE
Fix: remove RepoStub fake classs from unit tests

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -137,7 +137,7 @@ class BaseCliStub(object):
 
     def read_all_repos(self):
         """Read repositories information."""
-        self.repos.add(RepoStub('main'))
+        self.repos.add(dnf.repo.Repo(name='main'))
 
     def read_comps(self):
         """Read groups information."""
@@ -168,28 +168,6 @@ class CliStub(object):
 class DemandsStub(object):
     pass
 
-
-class RepoStub(object):
-    """A class mocking `dnf.repo.Repo`"""
-
-    enabled = True
-
-    def __init__(self, id_):
-        """Initialize the repository."""
-        self.id = id_
-        self.priority = 99
-        self.cost = 1000
-
-    def _valid(self):
-        """Return a message if the repository is not valid."""
-
-    def enable(self):
-        """Enable the repo"""
-        self.enabled = True
-
-    def disable(self):
-        """Disable the repo"""
-        self.enabled = False
 
 class TestCase(unittest.TestCase):
     def assertEmpty(self, collection):


### PR DESCRIPTION
Uses dnf.repo.Repo class instead of faking it by StubRepo.
It is required due to changes in DNF.