### PR TITLE
Save install_weak_deps option to persist through reboot (RhBug:1638689)

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -155,6 +155,7 @@ class State(object):
     best = _prop("best")
     exclude = _prop("exclude")
     install_packages = _prop("install_packages")
+    install_weak_deps = _prop("install_weak_deps")
 
 # --- Plymouth output helpers -------------------------------------------------
 
@@ -391,6 +392,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
         self.base.conf.gpgcheck = self.state.gpgcheck
         self.base.conf.best = self.state.best
         self.base.conf.exclude = self.state.exclude
+        self.base.conf.install_weak_deps = self.state.install_weak_deps
         # don't try to get new metadata, 'cuz we're offline
         self.cli.demands.cacheonly = True
         # and don't ask any questions (we confirmed all this beforehand)
@@ -544,6 +546,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
             state.system_releasever = system_ver
             state.target_releasever = self.base.conf.releasever
             state.install_packages = install_packages
+            state.install_weak_deps = self.base.conf.install_weak_deps
             state.enable_disable_repos = self.opts.repos_ed
             state.destdir = self.base.conf.destdir
         logger.info(DOWNLOAD_FINISHED_MSG)

--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -394,6 +394,7 @@ class DownloadCommandTestCase(CommandTestCase):
         self.command.base.conf.releasever = "35"
         self.command.base.conf.gpgcheck = True
         self.command.base.conf.destdir = "/grape/wine"
+        self.command.base.conf.install_weak_deps = True
         self.command.transaction_download()
         with system_upgrade.State() as state:
             self.assertEqual(state.download_status, "complete")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1638689
When the install_weak_deps is set to False during the download
(--setopt=install_weak_deps=False), the upgrade fails as some weak
dependencies are missing. Therefore, the option must be reused during
the upgrade.