### PR TITLE
[lint]: follow tox.ini/flake8 with line length

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -21,7 +21,7 @@ disable "-d W0141" # used builtin 'map' function
 disable "-d W0142" # used star magic
 
 VAR_NAMES=--variable-rgx='[a-z_][a-z0-9_]*$'
-MISC=--max-line-length=82
+MISC=--max-line-length=100
 
 pylint --rcfile=/dev/null --reports=n $DISABLED "$VAR_NAMES" $MISC $* \
     "$TEMPLATE" \


### PR DESCRIPTION
tox.ini has 100 and scripts/lint had 82. As snapper and system_upgrade plugins have several lines with length more than 82 but less than 100 I assume definitive length is 100.