### PR TITLE
Add missing doc TOC

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,6 +24,7 @@ This documents extras plugins of DNF:
 .. toctree::
    :maxdepth: 1
 
+   kickstart
    release_notes
    rpmconf
    snapper


### PR DESCRIPTION
The kickstart plugin wasn't listed in the doc TOC.  This should fix the issue.