### PR TITLE
[system_upgrade] fix: When running 'clean' command actually clean state totally

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -534,14 +534,10 @@ class SystemUpgradeCommand(dnf.cli.Command):
 
     def run_clean(self):
         logger.info(_("Cleaning up downloaded data..."))
+        self.state.clear()
         clear_dir(self.base.conf.cachedir)
         if self.base.conf.destdir:
             clear_dir(self.base.conf.destdir)
-        with self.state as state:
-            state.download_status = None
-            state.upgrade_status = None
-            state.destdir = None
-            state.install_packages = {}
 
     def run_log(self):
         if self.opts.number:


### PR DESCRIPTION
I'm not sure if this fix is proper. But system-upgrade leaves file back, mine:

{noformat}
{"distro_sync": true, "datadir": "/var/lib/dnf/system-upgrade", "exclude": [], "system_releasever": "29", "target_releasever": "30", "best": false, "allow_erasing": false, "download_status": null, "upgrade_status": null, "install_packages": {}, "enable_disable_repos": [], "destdir": null, "gpgcheck": true, "install_weak_deps": false, "module_platform_id": null}
{noformat}

And when I try to do offline-upgrade, system-upgrade gives error:

{noformat}
Jun 19 21:19:05 workstation python3[933]: detected unhandled Python exception in '/usr/bin/dnf'
Jun 19 21:19:05 workstation dnf[933]: Traceback (most recent call last):
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/bin/dnf", line 58, in <module>
Jun 19 21:19:05 workstation dnf[933]:     main.user_main(sys.argv[1:], exit_code=True)
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 192, in user_main
Jun 19 21:19:05 workstation dnf[933]:     errcode = main(args)
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 64, in main
Jun 19 21:19:05 workstation dnf[933]:     return _main(base, args, cli_class, option_parser_class)
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 95, in _main
Jun 19 21:19:05 workstation dnf[933]:     cli.configure(list(map(ucd, args)), option_parser())
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 954, in configure
Jun 19 21:19:05 workstation dnf[933]:     self.command.configure()
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf-plugins/system_upgrade.py", line 335, in configure
Jun 19 21:19:05 workstation dnf[933]:     self._call_sub("configure")
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf-plugins/system_upgrade.py", line 347, in _call_sub
Jun 19 21:19:05 workstation dnf[933]:     subfunc()
Jun 19 21:19:05 workstation dnf[933]:   File "/usr/lib/python3.7/site-packages/dnf-plugins/system_upgrade.py", line 410, in configure_upgrade
Jun 19 21:19:05 workstation dnf[933]:     repo.gpgcheck = repo.id in self.state.gpgcheck_repos
Jun 19 21:19:05 workstation dnf[933]: TypeError: argument of type 'NoneType' is not iterable
Jun 19 21:19:05 workstation systemd[1]: dnf-system-upgrade.service: Main process exited, code=exited, status=1/FAILURE
Jun 19 21:19:05 workstation systemd[1]: dnf-system-upgrade.service: Failed with result 'exit-code'.
Jun 19 21:19:05 workstation systemd[1]: Failed to start System Upgrade using DNF.
Jun 19 21:19:05 workstation systemd[1]: dnf-system-upgrade.service: Triggering OnFailure= dependencies.
{noformat}

And there was no clear way to get rid of old state.

My offline-upgrade has version checking capability. It refuses to do upgrades if dnf and plugin versions are not matching.