### PR TITLE
RFC: [tox] Major upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 TAGS
 *~
 build/
+.coverage
+.tox/
+coverage/
+flake8-report.txt
+dependency-check-report.html
+.instrumental.cov
+instrumental-result-html/
+.hypothesis/
+.idea/
+.secrets.baseline

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,418 @@
+[tox]
+envlist = py37, linters
+skipsdist=True
+
+# Top level meta envs
+
+[testenv]
+sitepackages = true
+# Required rpms in system:
+#   python2-dnf python2-kickstart python2-systemd
+#   python3-dnf python3-systemd
+whitelist_externals =
+    py{27,37}: {[testenv:coverage]whitelist_externals}
+    py{27,37}: {[testenv:nose]whitelist_externals}
+    py{27,37}: {[testenv:pytest]whitelist_externals}
+deps =
+    {[testenv:coverage]deps}
+commands_pre =
+    py{27,37}: {envbindir}/pip install --ignore-installed {[testenv]deps}
+commands =
+    py{27,37}: {[testenv:coverage]commands}
+
+[testenv:linters]
+deps =
+    {[testenv:pylint]deps}
+    {[testenv:flake8]deps}
+    {[testenv:autopep8]deps}
+    {[testenv:doc8]deps}
+    {[testenv:readme]deps}
+    {[testenv:pycycle]deps}
+    {[testenv:pydiatra]deps}
+    {[testenv:xenon]deps}
+    {[testenv:bandit]deps}
+    {[testenv:dodgy]deps}
+    {[testenv:safety]deps}
+commands_pre =
+    {envbindir}/pip install --ignore-installed {[testenv:linters]deps}
+    {[testenv:pylint]commands_pre}
+commands =
+    {[testenv:pylint]commands}
+    {[testenv:flake8]commands}
+    {[testenv:autopep8]commands}
+    {[testenv:doc8]commands}
+    {[testenv:readme]commands}
+    {[testenv:pycycle]commands}
+    {[testenv:pydiatra]commands}
+    {[testenv:xenon]commands}
+    {[testenv:bandit]commands}
+    {[testenv:dodgy]commands}
+    {[testenv:safety]commands}
+
+# Test runners
+[testenv:coverage]
+# https://github.com/nedbat/coveragepy
+# https://coverage.readthedocs.io/
+whitelist_externals =
+    coverage
+deps =
+    coverage
+    {[testenv:nose]deps}
+    {[testenv:pytest]deps}
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:coverage]deps}
+commands =
+        {envbindir}/coverage erase
+        {envbindir}/coverage run --branch --parallel-mode \
+                --omit='*/site-packages/*','.tox/*','tests/*' \
+        {envbindir}/nosetests
+        {envbindir}/coverage run --branch --parallel-mode \
+                --omit='*/site-packages/*','.tox/*','tests/*' \
+        {envbindir}/pytest
+        {envbindir}/coverage combine
+        {envbindir}/coverage report --show-missing
+        {envbindir}/coverage html -d coverage
+
+[testenv:instrumental]
+# https://github.com/nedbat/coveragepy
+# https://coverage.readthedocs.io/
+whitelist_externals =
+    instrumental
+deps =
+    instrumental
+    {[testenv:pytest]deps}
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:instrumental]deps}
+commands =
+        {envbindir}/instrumental --target plugins --ignore-assertions \
+        {envbindir}/pytest
+        {envbindir}/instrumental --target plugins --ignore-assertions --statements --report --html
+
+[testenv:nose]
+whitelist_externals =
+    nosetests
+deps =
+    hypothesis
+    nose
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:nose]deps}
+commands =
+    {envbindir}/nosetests {posargs}
+
+[testenv:pytest]
+whitelist_externals =
+    pytest
+deps =
+    hypothesis
+    pytest
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:pytest]deps}
+commands =
+    {envbindir}/pytest {posargs}
+
+# Autoformatter
+[testenv:black]
+sitepackages = false
+skip_install = true
+deps =
+    black>=19.3b0
+commands =
+    black {posargs:plugins tests}
+
+# Linters
+[testenv:autopep8]
+sitepackages = false
+deps =
+    autopep8
+commands =
+    autopep8 -a -a -a -a -a --experimental -r --diff {posargs:plugins tests}
+[testenv:bandit]
+# https://github.com/PyCQA/bandit
+sitepackages = false
+deps =
+    bandit
+commands =
+    bandit --ini tox.ini --recursive -s B404,B603,B607 {posargs:.}
+
+[testenv:dependency-check]
+sitepackages = false
+deps =
+    dependency-check
+commands =
+    dependency-check --disableAssembly -o build --project dnf-plugins-extras {posargs:-s .}
+
+[testenv:detect-secrets]
+sitepackages = false
+deps =
+    detect-secrets
+commands =
+    detect-secrets {posargs:audit .secrets.baseline}
+
+[testenv:detect-secrets-scan]
+whitelist_externals =
+    bash
+sitepackages = false
+deps =
+    detect-secrets
+commands =
+    bash -c "[ -f {toxinidir}/.secrets.baseline ] || echo '\{\}' > {toxinidir}/.secrets.baseline"
+    detect-secrets scan --update {toxinidir}/.secrets.baseline
+
+[testenv:doc8]
+sitepackages = false
+deps =
+    sphinx
+    doc8
+commands =
+    doc8 --config tox.ini {posargs:.}
+
+[testenv:dodgy]
+sitepackages = false
+deps =
+    dodgy
+commands =
+    dodgy {posargs}
+
+[testenv:flake8]
+sitepackages = false
+# Grouped by maintainers
+deps =
+# pycqa
+    flake8>=3.7.0
+    flake8-bugbear>=18.8.0
+    flake8-commas>=2.0.0
+    flake8-docstrings>=0.2.7
+    flake8-import-order>=0.9
+    pep8-naming
+# jparise
+    flake8-assertive==1.0.1
+# elijahandrews
+    flake8-blind-except==0.1.1
+# gforcada
+    flake8-builtins==1.4.1
+# Melevir
+    #flake8-class-attributes-order==0.0.2
+    #flake8-variables-names==0.0.1
+# adamchainz
+    flake8-comprehensions==2.1.0
+# tk0miya
+    flake8-coding==1.3.1
+# sobolevn
+    #flake8-eradicate==0.2.0
+# vharitonsky
+    flake8-i18n==0.1.0
+# mebeweber
+    flake8-mutable==1.2.0
+# afonasev
+    flake8-return==0.3.1
+# Korijn
+    flake8-self==0.2.2
+# yevhen-m
+    flake8-sorted-keys==0.2.0
+# DragosOprica
+    flake8-super-call==1.0.0
+# AdamChainz
+    flake8-tidy-imports==2.0.0
+# ar4s_pl
+    flake8-tuple==0.2.14
+
+commands =
+    {envbindir}/flake8 {posargs:plugins tests}
+
+[testenv:pycycle]
+sitepackages = false
+deps =
+    pycycle
+commands =
+    pycycle --source {toxinidir} --ignore .tox,.git
+
+[testenv:pydiatra]
+sitepackages = false
+deps =
+    pydiatra
+commands =
+    py3diatra {posargs:plugins/ tests/}
+
+[testenv:pyflakes]
+deps =
+    pyflakes
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:pyflakes]deps}
+commands =
+    {envbindir}/pyflakes {posargs:plugins tests}
+
+[testenv:pylint]
+deps = pylint
+commands_pre =
+# Force to use in env programs instead of systems
+# Deps are written out because of tox v3.4.0 bug.
+# It can not resolve multi value deps using deep resolution (aka from linters).
+# Use forked pylint-i18n because upstrean does not work with py3.
+    {envbindir}/pip install --ignore-installed {[testenv:pylint]deps} pylint-quotes git+https://github.com/LeoIannacone/python-pylint-i18n.git@7dd4a947970f896a796af9dd3a21b4765c61a484
+commands =
+    {envbindir}/pylint --rcfile=tox.ini {posargs:plugins tests}
+
+[testenv:pyt]
+# https://github.com/python-security/pyt
+# Currently these bugs prevent to use this:
+#   https://github.com/python-security/pyt/issues/195
+#   https://github.com/python-security/pyt/issues/196
+deps =
+    python-taint
+commands_pre =
+# Force to use in env programs instead of systems
+    {envbindir}/pip install --ignore-installed {[testenv:pyt]deps}
+commands =
+    pyt --recursive --exclude tests/mock.py {posargs:plugins/ tests/}
+
+[testenv:readme]
+# https://github.com/pypa/readme_renderer
+deps =
+    readme_renderer
+commands =
+# No setup.py
+#    {envbindir}/python setup.py check -r -s
+    {envbindir}/python -m readme_renderer -o /dev/null README.rst
+
+[testenv:safety]
+# https://pyup.io/safety/
+# https://github.com/pyupio/safety
+description = Safety checks used dependencies for known security vulnerabilities
+sitepackages = false
+ignore_outcome = false
+deps =
+    safety
+commands =
+# This is ignored just to make safety pass by default
+# 26077: python-augeas: NOT fixed in 0.5.0-13
+# 35015: pycrypto: 2.6.1-13
+# 36499: marshmallow: 2.11.1-8
+    safety check --cache --ignore 26077 --ignore 35015 --ignore 36499 --full-report
+
+[testenv:xenon]
+sitepackages = false
+deps =
+    xenon
+commands =
+    xenon --ignore .tox,.git --exclude '*/mock.py' --max-absolute B --max-modules A --max-average A .
+
+# Per programs sections
+
+[bandit]
+# one line, comma delim, without additional spaces
+# Exclude tests/mock.py because it is not needed with py3
+exclude = .git,.tox,./.git,./.tox,tests/mock.py
+
+[doc8]
+ignore = D001
+ignore-path =
+    CMakeLists.txt,
+    */CMakeLists.txt,
+    */*/CMakeLists.txt,
+    *.egg-info,
+    .git,
+    .tox,
+
 [flake8]
-# C0111: docstrings
-# I0011: locally disabled warnings
-# R0801: similar lines
-# R0904: too many public methods
-# R0911: too many return statements
-# R0912: too many branches
-# R0913: too many arguments
-# R0903: too few public methods
-# W0141: used builtin 'map' function
-# W0142: used star magic
-# W0212: access to a protected member
-ignore = C0111,I0011,R0801,R0904,R0911,R0912,R0913,R0903,W0141,W0142,W0212
-exclude = .git,__pycache__
+output-file=flake8-report.txt
+tee = True
+
+max-complexity= 10
 max-line-length = 100
+
+ignore =
+    C101, # Coding magic comment not found
+    D100, # Missing docstring in public module
+    D101, # Missing docstring in public class
+    D102, # Missing docstring in public method
+    D103, # Missing docstring in public function
+    D105, # Missing docstring in magic method
+    D107, # Missing docstring in __init__
+    D400, # First line should end with a period
+    I100, # Import statements are in the wrong order
+    I101, # Imported names are in the wrong order
+    I201, # Missing newline between import groups
+    I202, # Additional newline in a group of imports
+    W504, # line break after binary operator
+
+# Don't want to sprinkle files with flake8 magick comments as they provide no info
+per-file-ignores =
+# missing trailing comma
+    plugins/snapper.py:C812
+# Missing docstring in public package
+    tests/__init__.py:D104
+# line break after binary operator
+    tests/test_kickstart.py:W504
+# Missing docstring in public package
+    tests/dnfpluginsextras/__init__.py:D104
+
+exclude =
+    *.egg-info,
+    *.pyc,
+    .cache,
+    .eggs,
+    .git,
+    .tox,
+    __pycache__,
+# Exclude because it is generated
+    docs/conf.py,
+# Exclude because it is only for py2
+    tests/mock.py,
+
+[pytest]
+addopts = --capture=no
+console_output_style = count
+filterwarnings =
+# rpmconf/rpmconf.py:173: DeprecationWarning: 'U' mode is deprecated
+    ignore::DeprecationWarning
+
+# pylint
+[MASTER]
+jobs = 0
+load-plugins =
+# https://github.com/LeoIannacone/python-pylint-i18n
+    missing_gettext,
+# https://github.com/edaniszewski/pylint-quotes
+    pylint_quotes,
+ignore-patterns =
+    \.egg-info$,
+    \.pyc$
+    ^\.cache$,
+    ^\.eggs$,
+    ^\.git$,
+    ^\.tox$,
+    ^__pycache__$,
+    ^conf\.py$,
+    ^mock\.py$,
+
+# pylint_quotes
+triple-quote = double
+docstring-quote = double
+
+[DESIGN]
+# Maximum number of attributes for a class (see R0902).
+max-attributes=15
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=26
+
+[LOGGING]
+logging-format-style=new
+
+[TYPECHECK]
+# Because tox uses venv and then distutils is monkey patched
+ignored-modules = distutils
+
+[MESSAGES CONTROL]
+disable =
+    C0103, # Variable name "%s" doesn't conform to snake_case naming style (invalid-name)
+    C0111, # Missing method docstring (missing-docstring)
+    C0411, # standard import "%s" should be placed before "%s" (wrong-import-order)
+    C4001, # Invalid string quote %s, should be %s (invalid-string-quote)
+    R0205, # Class '%s' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
+    W0511, # TODO %s (fixme)


### PR DESCRIPTION
py27 does not work any more in Fedora 30, so it is by default not enabled.

My version of tox.ini here.