### PR TITLE
[tests] Fix expected message from rpmconf.

### DIFF
--- a/tests/test_rpmconf.py
+++ b/tests/test_rpmconf.py
@@ -182,7 +182,7 @@ class TestRpmConf(unittest.TestCase):
 
             lines = stdout.getvalue().splitlines()
 
-        expected_last_line = "File {0} was removed by 3rd party. Skipping.".format(new_path)
+        expected_last_line = "File {0} has been merged.".format(new_path)
         self.assertEqual(lines[-1], expected_last_line)
 
     def test_diff_output(self):


### PR DESCRIPTION
The output of rpmconf changed with commit:
https://github.com/xsuchy/rpmconf/commit/b704842162cc03c1fd22e86bd8e0262344a7f5ba

---

Adding a "blocked" label, because the newer rpmconf is not on all Fedoras yet.
This test started to fail on F32, see log: https://kojipkgs.fedoraproject.org//work/tasks/7042/37837042/build.log

@xsuchy, can you please look at this? I just want to make sure that I understand the commit in rpmconf correctly, i.e. rpmconf now always outputs ``File <path> has been merged.`` for the "M" option.