### PR TITLE
Permit return of list or dict_keys

### DIFF
--- a/plugins/showvars.py
+++ b/plugins/showvars.py
@@ -49,14 +49,14 @@ class ShowVarsCommand(commands.Command):
         dnfvars = dnf.conf.substitutions.Substitutions()
         dnfvars.update_from_etc(self.base.conf.installroot)
 
-        defined = dnfvars.keys()
+        defined = list(dnfvars.keys())
         defined.append('basearch')
         defined.append('releasever')
         defined.sort()
         for var in defined:
-            if defined == 'basearch':
+            if var == 'basearch':
                 print("basearch=" + self.base.conf.basearch)
-            elif defined == 'releasever':
+            elif var == 'releasever':
                 print("releasever=" + self.base.conf.releasever)
             else:
                 print(var + '=' + dnfvars[var])


### PR DESCRIPTION
There was a minor error in the use of `dict_keys` and the loop that prevented it from executing except on python2.7.

This is corrected so it now works as it should.