### PR TITLE
Fix tests for Fedora > 30, rpmconf changed output

### DIFF
--- a/tests/test_rpmconf.py
+++ b/tests/test_rpmconf.py
@@ -182,8 +182,12 @@ class TestRpmConf(unittest.TestCase):
 
             lines = stdout.getvalue().splitlines()
 
-        expected_last_line = "File {0} was removed by 3rd party. Skipping.".format(new_path)
-        self.assertEqual(lines[-1], expected_last_line)
+        expected_last_line_to_f30 = "File {0} was removed by 3rd party. Skipping.".format(new_path)
+        # Newer rpmconf changed output since F31
+        expected_last_line_from_f31 = "File {0} has been merged.".format(new_path)
+
+        self.assertRegexpMatches(lines[-1], "{0}|{1}"
+                                 .format(expected_last_line_to_f30, expected_last_line_from_f31))
 
     def test_diff_output(self):
         self._create_conf()


### PR DESCRIPTION
It should also fix our copr nightly builds for F31 and F32.