### PR TITLE
Set clean_requirements_on_remove=False during remove (RhBug:1764169)

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -452,6 +452,9 @@ class SystemUpgradeCommand(dnf.cli.Command):
         # and don't ask any questions (we confirmed all this beforehand)
         self.base.conf.assumeyes = True
         self.cli.demands.transaction_display = PlymouthTransactionProgress()
+        # upgrade operation already removes all element that must be removed. Additional removal
+        # could trigger unwanted changes in transaction.
+        self.base.conf.clean_requirements_on_remove = False
 
     def configure_clean(self):
         self.cli.demands.root_user = True


### PR DESCRIPTION
After direct removal of packages in upgrade transaction, it is not
needed to look for removal of unused dependencies. Also in some cases it
could trigger reinstall step of some packages. Consequence is
requirement of additional downloads, that are not allowed during
the reboot.

https://bugzilla.redhat.com/show_bug.cgi?id=1764169