### PR TITLE
Do not show Operation aborted as an error (RhBug:1797427)

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -26,6 +26,7 @@ import json
 import os
 import os.path
 import re
+import sys
 import uuid
 
 from systemd import journal
@@ -425,7 +426,8 @@ class SystemUpgradeCommand(dnf.cli.Command):
                         '"dnf --refresh upgrade". Do you want to continue')
                 if self.base.conf.assumeno or not self.base.output.userconfirm(
                         msg='{} [y/N]: '.format(msg), defaultyes_msg='{} [Y/n]: '.format(msg)):
-                    raise CliError(_("Operation aborted."))
+                    logger.error(_("Operation aborted."))
+                    sys.exit(1)
             check_release_ver(self.base.conf, target=self.opts.releasever)
         self.cli.demands.root_user = True
         self.cli.demands.resolving = True


### PR DESCRIPTION
New output:
sudo dnf system-upgrade download --releasever=31
Before you continue ensure that your system is fully upgraded by running
"dnf --refresh upgrade". Do you want to continue [y/N]: N
Operation aborted.

https://bugzilla.redhat.com/show_bug.cgi?id=1797427