### PR TITLE
[system-upgrade] Upgrade groups and environments

### DIFF
--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -31,6 +31,9 @@ version (``--releasever``) compared to installed version.
 release. It replaces fedup (the old Fedora Upgrade tool). Before you proceed ensure that your system
 is fully upgraded (``dnf --refresh upgrade``).
 
+The ``system-upgrade`` command also performes additional actions necessary for the upgrade of the
+system, for example an upgrade of groups and environments.
+
 --------
 Synopsis
 --------

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -580,6 +580,16 @@ class SystemUpgradeCommand(dnf.cli.Command):
         else:
             self.base.upgrade_all()
 
+        if self.opts.command not in ['offline-upgrade', 'offline-distrosync']:
+            # Mark all installed groups and environments for upgrade
+            self.base.read_comps()
+            installed_groups = [g.id for g in self.base.comps.groups if self.base.history.group.get(g.id)]
+            if installed_groups:
+                self.base.env_group_upgrade(installed_groups)
+            installed_environments = [g.id for g in self.base.comps.environments if self.base.history.env.get(g.id)]
+            if installed_environments:
+                self.base.env_group_upgrade(installed_environments)
+
         with self.state as state:
             state.download_status = 'downloading'
             state.target_releasever = self.base.conf.releasever


### PR DESCRIPTION
Also add switch --no-group-upgrade to disable the group upgrade

= changelog =
msg: [system-upgrade] Upgrade groups and environments; can be switched off with --no-group-upgrade
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1845562
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1860408
related: https://bugzilla.redhat.com/show_bug.cgi?id=1814306