### PR TITLE
system-upgrade: Add an env variable to control reboot

### DIFF
--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -125,6 +125,10 @@ Notes
 ``dnf system-upgrade reboot`` does not create a "System Upgrade" boot item. The
 upgrade will start regardless of which boot item is chosen.
 
+The ``DNF_SYSTEM_UPGRADE_NO_REBOOT`` environment variable can be set to a
+non-empty value to disable the actual reboot performed by ``system-upgrade``
+(e.g. for testing purposes).
+
 Since this is a DNF plugin, options accepted by ``dnf`` are also valid here,
 such as ``--allowerasing``.
 See :manpage:`dnf(8)` for more information.

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -71,7 +71,10 @@ STATE_VERSION = 2
 
 
 def reboot():
-    Popen(["systemctl", "reboot"])
+    if os.getenv("DNF_SYSTEM_UPGRADE_NO_REBOOT", default=False):
+        logger.info(_("Reboot turned off, not rebooting."))
+    else:
+        Popen(["systemctl", "reboot"])
 
 
 def get_url_from_os_release():


### PR DESCRIPTION
If the DNF_SYSTEM_UPGRADE_NO_REBOOT env variable is set, the plugin will
not actually reboot.

= changelog =
msg: Add the DNF_SYSTEM_UPGRADE_NO_REBOOT env variable to control system-upgrade reboot.
type: enhancement