### PR TITLE
Set installroot in tmp dir to avoid problems with unittests

### DIFF
--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -410,7 +410,7 @@ class DownloadCommandTestCase(CommandTestCase):
         self.command.opts.repos_ed = []
         self.cli.demands.allow_erasing = "allow_erasing"
         self.command.base.conf.best = True
-        self.command.base.conf.installroot = "/"
+        self.command.base.conf.installroot = self.statedir
         self.command.base.conf.releasever = "35"
         self.command.base.conf.gpgcheck = True
         self.command.opts.destdir = self.statedir
@@ -440,7 +440,7 @@ class DownloadCommandTestCase(CommandTestCase):
         self.command.opts.repos_ed = []
         self.cli.demands.allow_erasing = "allow_erasing"
         self.command.base.conf.best = True
-        self.command.base.conf.installroot = "/"
+        self.command.base.conf.installroot = self.statedir
         self.command.base.conf.releasever = "35"
         self.command.base.conf.gpgcheck = True
         self.command.opts.destdir = self.statedir


### PR DESCRIPTION
======================================================================
ERROR: test_transaction_download (tests.test_system_upgrade.DownloadCommandTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/dnf/rpm/__init__.py", line 39, in detect_releasever
    idx = ts.dbMatch('provides', distroverpkg)
  File "/usr/lib/python3.8/site-packages/dnf/rpm/transaction.py", line 59, in dbMatch
    mi = self.ts.dbMatch(*args, **kwds)
_rpm.error: rpmdb open failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/dnf-plugins-extras-4.0.12/tests/test_system_upgrade.py", line 420, in test_transaction_download
    self.command.transaction_download()
  File "/builddir/build/BUILDROOT/dnf-plugins-extras-4.0.12-1.fc32.x86_64/usr/lib/python3.8/site-packages/dnf-plugins/system_upgrade.py", line 714, in transaction_download
    system_ver = dnf.rpm.detect_releasever(self.base.conf.installroot)
  File "/usr/lib/python3.8/site-packages/dnf/rpm/__init__.py", line 41, in detect_releasever
    raise dnf.exceptions.Error('Error: %s' % str(e))
dnf.exceptions.Error: Error: rpmdb open failed

======================================================================
ERROR: test_transaction_download_offline_upgrade (tests.test_system_upgrade.DownloadCommandTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/dnf/rpm/__init__.py", line 39, in detect_releasever
    idx = ts.dbMatch('provides', distroverpkg)
  File "/usr/lib/python3.8/site-packages/dnf/rpm/transaction.py", line 59, in dbMatch
    mi = self.ts.dbMatch(*args, **kwds)
_rpm.error: rpmdb open failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/dnf-plugins-extras-4.0.12/tests/test_system_upgrade.py", line 450, in test_transaction_download_offline_upgrade
    self.command.transaction_download()
  File "/builddir/build/BUILDROOT/dnf-plugins-extras-4.0.12-1.fc32.x86_64/usr/lib/python3.8/site-packages/dnf-plugins/system_upgrade.py", line 714, in transaction_download
    system_ver = dnf.rpm.detect_releasever(self.base.conf.installroot)
  File "/usr/lib/python3.8/site-packages/dnf/rpm/__init__.py", line 41, in detect_releasever
    raise dnf.exceptions.Error('Error: %s' % str(e))
dnf.exceptions.Error: Error: rpmdb open failed