### PR TITLE
system_upgrade_test: Don't access host files in releasever detection

### DIFF
--- a/tests/test_system_upgrade.py
+++ b/tests/test_system_upgrade.py
@@ -251,9 +251,13 @@ class UtilTestCase(unittest.TestCase):
 class CommandTestCaseBase(unittest.TestCase):
     def setUp(self):
         self.datadir = tempfile.mkdtemp(prefix="system_upgrade_test_datadir-")
+        self.installroot = tempfile.mkdtemp(prefix="system_upgrade_test_installroot-")
         system_upgrade.SystemUpgradeCommand.DATADIR = self.datadir
         self.cli = mock.MagicMock()
-        self.cli.base.conf.installroot = "/"
+        # the installroot is not strictly necessary for the test, but
+        # releasever detection is accessing host system files without it, and
+        # this fails on permissions in COPR srpm builds (e.g. from rpm-gitoverlay)
+        self.cli.base.conf.installroot = self.installroot
         self.command = system_upgrade.SystemUpgradeCommand(cli=self.cli)
         self.command.base.conf.cachedir = os.path.join(self.datadir, "cache")
         self.command.base.conf.destdir = None


### PR DESCRIPTION
This was fixed in a8cead0 and broken again in d51c3ef. In COPR builds
(seems only when building from srpm - through rpm-gitoverlay),
releasever detection attempts to read host system files and fails on
permissions.

Lets set installroot to a temp dir to work around that.