### PR TITLE
Power off when system upgrade is done

### DIFF
--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -75,6 +75,12 @@ def reboot():
     else:
         Popen(["systemctl", "reboot"])
 
+def poweroff():
+    if os.getenv("DNF_SYSTEM_UPGRADE_NO_SHUTDOWN", default = False):
+        logger.info(_("Shutdown turned off, not shutting down."))
+    else:
+        Popen(["systemctl", "poweroff"])
+
 
 def get_url_from_os_release():
     key = "UPGRADE_GUIDE_URL="
@@ -680,7 +686,7 @@ class SystemUpgradeCommand(dnf.cli.Command):
                         UPGRADE_FINISHED_ID)
         self.run_clean()
         if self.opts.tid[0] == "upgrade":
-            reboot()
+            poweroff()
 
 
 class OfflineUpgradeCommand(SystemUpgradeCommand):


### PR DESCRIPTION
Hi there,

I suspect that most users will probably run a system upgrade at a time when they know that they won't be using the machine for some time. This is because they don't know in advance how long a system upgrade is going to take. This is probably at the end of the work day or before they go to bed, so in all likelihood the machine is going to sit there the whole night and consume power for no reason. I think it would be better to instead just power off the machine. Do you agree with my reasoning?