### PR TITLE
Remove zanata config

### DIFF
--- a/po/zanata.xml
+++ b/po/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://fedora.zanata.org/</url>
-  <project>dnf-plugins-extras</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
Weblate is now used for translations, so zanata config is no longer
needed.