### PR TITLE
add dnf-plugin-rebuild-initrd

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Ville Skyttä <ville.skytta@iki.fi>
 Michael Scherer <misc@redhat.com>
 Will Woods <wwoods@redhat.com>
 Neal Gompa <ngompa13@gmail.com>
+Andrzej Pacanowski <andrzej.pacanowski@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ RPM packages for individual plugins are available in official Fedora repositorie
    dnf install dnf-plugin-system-upgrade
    dnf install dnf-plugin-torproxy
    dnf install dnf-plugin-tracer
+   dnf install dnf-plugin-rebuild-initrd
 
 Nigthly builds can be installed from `copr repository <https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/>`_.
 

--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -147,6 +147,19 @@ Provides:       python3-%{name}-showvars = %{version}-%{release}
 This plugin dumps the current value of any defined DNF variables.  For example
 $releasever and $basearch.
 
+%package -n python3-dnf-plugin-rebuild-initrd
+Summary:        Initrd rebuild after new kernel Plugin for DNF
+Requires:       python3-%{name}-common = %{version}-%{release}
+%{?python_provide:%python_provide python3-%{name}-rebuild-initrd}
+Requires:       akmods
+Requires:       dracut
+Provides:       dnf-plugin-rebuild-initrd = %{version}-%{release}
+Provides:       python3-%{name}-rebuild-initrd = %{version}-%{release}
+
+%description -n python3-dnf-plugin-rebuild-initrd
+Runs akmods and dracut for each new kernel installed.
+This can solve problem of Nvidia hybrid cards users where nvidia.ko is
+required to show plymouth password screen over HDMI.
 
 %prep
 %autosetup
@@ -219,5 +232,10 @@ PYTHONPATH="%{buildroot}%{python3_sitelib}:%{buildroot}%{python3_sitelib}/dnf-pl
 %{python3_sitelib}/dnf-plugins/showvars.*
 %{python3_sitelib}/dnf-plugins/__pycache__/showvars.*
 %{_mandir}/man8/dnf-showvars.*
+
+%files -n python3-dnf-plugin-rebuild-initrd
+%{python3_sitelib}/dnf-plugins/rebuild_initrd.*
+%{python3_sitelib}/dnf-plugins/__pycache__/rebuild_initrd.*
+%{_mandir}/man8/dnf-rebuild-initrd.*
 
 %changelog

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -27,5 +27,6 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-kickstart.8
 if (${PYTHON_VERSION_MAJOR} STREQUAL "3")
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-rpmconf.8
         ${CMAKE_CURRENT_BINARY_DIR}/dnf-torproxy.8
+        ${CMAKE_CURRENT_BINARY_DIR}/dnf-rebuild-initrd.8
         DESTINATION share/man/man8)
 endif()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -247,6 +247,7 @@ man_pages = [
     ('torproxy', 'dnf-torproxy', u'DNF torproxy Plugin', AUTHORS, 8),
     ('showvars', 'dnf-showvars', u'DNF showvars Plugin', AUTHORS, 8),
     ('tracer', 'dnf-tracer', u'DNF tracer Plugin', AUTHORS, 8),
+    ('rebuild-initrd', 'dnf-rebuild-initrd', u'DNF rebuild-initrd Plugin', AUTHORS, 8),
 ]
 
 # If true, show URL addresses after external links.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,7 @@ This documents extras plugins of DNF:
    system-upgrade
    torproxy
    tracer
+   rebuild-initrd
 
 
 ========

--- a/doc/rebuild-initrd.rst
+++ b/doc/rebuild-initrd.rst
@@ -1,0 +1,51 @@
+..
+  Copyright (C) 2021 Andrzej Pacanowski
+
+  This copyrighted material is made available to anyone wishing to use,
+  modify, copy, or redistribute it subject to the terms and conditions of
+  the GNU General Public License v.2, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY expressed or implied, including the implied warranties of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+  Public License for more details.  You should have received a copy of the
+  GNU General Public License along with this program; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+  source code or documentation are not subject to the GNU General Public
+  License and may only be used or replicated with the express permission of
+  Red Hat, Inc.
+
+
+=========================
+DNF rebuild-initrd Plugin
+=========================
+
+Runs akmods and dracut for each new kernel installed.
+
+This can solve problem of Nvidia hybrid cards users where nvidia.ko is
+required to show plymouth password screen over HDMI.
+
+-------------
+Configuration
+-------------
+
+``/etc/dnf/plugins/rebuilinitrd.conf``
+
+The minimal plugin configuration file should consists of `[main]` section with `check_module_exists` parameter.::
+
+  [main]
+  check_module_exists = 
+
+``check_module_exists``
+    string, default: empty
+
+    Optionally we can also check initrd image for presence of desired module eg. nvidia.ko
+
+
+--------
+See Also
+--------
+
+:manpage:`dracut(8)`.
+:manpage:`akmods(8)`.
+:manpage:`lsinitrd(1)`.

--- a/etc/dnf/plugins/rebuildinitrd.conf
+++ b/etc/dnf/plugins/rebuildinitrd.conf
@@ -1,0 +1,4 @@
+[main]
+# You can enable check for particular kernel module by adding eg. nvidia.ko
+# To verify whats the name of desired kernel object look into "lsinitrd /boot/initramfs-{kernel_name}.img"
+check_module_exists = 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -5,5 +5,6 @@ INSTALL (FILES snapper.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES tracer.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES kickstart.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 INSTALL (FILES system_upgrade.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
+INSTALL (FILES rebuild_initrd.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf-plugins)
 
 ADD_SUBDIRECTORY (dnfpluginsextras)

--- a/plugins/rebuild_initrd.py
+++ b/plugins/rebuild_initrd.py
@@ -1,0 +1,89 @@
+# rebuild-initrd.py, runs akmods and dracut after installation of new kernels.
+#
+# Copyright (C) 2021 Andrzej Pacanowski <andrzej.pacanowski@gmail.com>
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import subprocess
+
+from dnfpluginsextras import logger
+import dnf
+
+
+class RebuildInitrd(dnf.Plugin):
+    """
+    Simple plugin that checks if new kernel is installed and runs akmod / dracut for it.
+    """
+    name = 'rebuildinitrd'
+
+    def __init__(self, base, cli):
+        self.base = base
+        self._conf_check_module_exists = ''
+
+    def config(self):
+        conf = self.read_config(self.base.conf)
+        if conf.has_section('main') and conf.has_option('main', 'check_module_exists'):
+            self._conf_check_module_exists = conf.get('main', 'check_module_exists').strip()
+
+    def _akmod(self, kernels):
+        subprocess.check_call([
+            'akmods',
+            '--force',
+            '--kernels',
+            *kernels
+        ])
+
+    def _dracut(self, kernels):
+        for kernel in kernels:
+            subprocess.check_call([
+                'dracut',
+                '--force',
+                '--kver',
+                kernel
+            ])
+
+    def _check_module_exists(self, kernels):
+        if self._conf_check_module_exists:
+            logger.info(
+                "%s: Check if %s is available in kernel.",
+                self.name, self._conf_check_module_exists
+            )
+            for kernel in kernels:
+                output = subprocess.check_output([
+                    'lsinitrd',
+                    f'/boot/initramfs-{kernel}.img'
+                ], universal_newlines=True)
+                if self._conf_check_module_exists in output:
+                    logger.info("%s: Successfuly built for %s", self.name, kernel)
+                else:
+                    logger.critical("%s: ERROR not built for %s", self.name, kernel)
+
+    def transaction(self):
+        if not self.base.transaction:
+            return
+
+        kernels = [
+            f"{package.version}-{package.release}.{package.arch}" for package in filter(
+                lambda e: e.name == "kernel",
+                self.base.transaction.install_set
+            )
+        ]
+
+        if kernels:
+            logger.info("%s: Kernels for which to rebuild initrd %s", self.name, kernels)
+            self._akmod(kernels)
+            self._dracut(kernels)
+            self._check_module_exists(kernels)


### PR DESCRIPTION
Hi!
This is something which I'm using on my daily basis. I've finally decided to share it with the world :)

Use-case:
I'm an unfortunate nvidia-intel hybrid user and I've a full disk encryption enabled thus on each startup I need to enter password on plymouth screen.
Everything's fine until I want that to be visible on HDMI connected device: that requires nvidia.ko in initrd image.
Unfortunately those would be build ON-DEMAND on next restart which is most often too-late and I end up opening my laptop.

With this package installed it ensures that akmods/dracut is forcefully run after 'kernel' is installed.

Test:

```
sudo dnf reinstall kernel
Alias tip: _ dnf reinstall kernel
Last metadata expiration check: 2:05:51 ago on sob, 18 wrz 2021, 11:15:05.
Dependencies resolved.
=====================================================================================================================================================================================================================
 Package                                         Architecture                                    Version                                                      Repository                                        Size
=====================================================================================================================================================================================================================
Reinstalling:
 kernel                                          x86_64                                          5.13.16-200.fc34                                             updates                                           78 k

Transaction Summary
=====================================================================================================================================================================================================================

Total download size: 78 k
Installed size: 0
Is this ok [y/N]: y
Downloading Packages:
kernel-5.13.16-200.fc34.x86_64.rpm                                                                                                                                                   108 kB/s |  78 kB     00:00
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                 38 kB/s |  78 kB     00:02
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                             1/1
  Reinstalling     : kernel-5.13.16-200.fc34.x86_64                                                                                                                                                              1/2
  Cleanup          : kernel-5.13.16-200.fc34.x86_64                                                                                                                                                              2/2
  Running scriptlet: kernel-5.13.16-200.fc34.x86_64                                                                                                                                                              2/2
  Verifying        : kernel-5.13.16-200.fc34.x86_64                                                                                                                                                              1/2
  Verifying        : kernel-5.13.16-200.fc34.x86_64                                                                                                                                                              2/2
rebuildinitrd: Kernels for which to rebuild initrd ['5.13.16-200.fc34.x86_64']
Checking kmods exist for 5.13.16-200.fc34.x86_64           [  OK  ]
rebuildinitrd: Check if nvidia.ko is available in kernel.
rebuildinitrd: Successfuly built for 5.13.16-200.fc34.x86_64

Reinstalled:
  kernel-5.13.16-200.fc34.x86_64

Complete!
```