### PR TITLE
Replace deprecated assertRegexpMatches() (RhBug: 2034178)

### DIFF
--- a/tests/test_rpmconf.py
+++ b/tests/test_rpmconf.py
@@ -176,8 +176,8 @@ class TestRpmConf(unittest.TestCase):
         # Newer rpmconf changed output since F31
         expected_last_line_from_f31 = "File {0} has been merged.".format(new_path)
 
-        self.assertRegexpMatches(lines[-1], "{0}|{1}"
-                                 .format(expected_last_line_to_f30, expected_last_line_from_f31))
+        self.assertRegex(lines[-1], "{0}|{1}"
+                         .format(expected_last_line_to_f30, expected_last_line_from_f31))
 
     def test_diff_output(self):
         self._create_conf()


### PR DESCRIPTION
This fixes building with Python 3.11.

= changelog =
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2034178