### PR TITLE
snapper: Add support for specifying snapper config name.

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -190,6 +190,7 @@ ln -sf %{_mandir}/man8/dnf-system-upgrade.8.gz %{buildroot}%{_mandir}/man8/dnf-o
 %{_mandir}/man8/dnf-rpmconf.*
 
 %files -n python3-dnf-plugin-snapper
+%config(noreplace) %{_sysconfdir}/dnf/plugins/snapper.conf
 %{python3_sitelib}/dnf-plugins/snapper.*
 %{python3_sitelib}/dnf-plugins/__pycache__/snapper.*
 %{_mandir}/man8/dnf-snapper.*

--- a/doc/snapper.rst
+++ b/doc/snapper.rst
@@ -25,3 +25,17 @@ Creates a pair of snapshots of root filesystem. One snapshot is created just bef
 The user is not supposed to interact with the plugin in any way.
 
 .. warning:: There is no mechanism to ensure data consistency during creating a snapshot. Files which are written at the same time as snapshot is created (eg. database files) can be corrupted or partially written in snapshot. Restoring such files will cause problems. Moreover, some system files must never be restored. Recommended is to only restore files that belong to the action you want to revert.
+
+-------------
+Configuration
+-------------
+
+``/etc/dnf/plugins/snapper.conf``
+
+[main] section optional parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``snapper_config``
+    string, default: ``root``
+
+    Specifies which snapper config should be used when taking snapshots.

--- a/etc/dnf/plugins/CMakeLists.txt
+++ b/etc/dnf/plugins/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (${PYTHON_VERSION_MAJOR} STREQUAL "3")
 INSTALL (FILES torproxy.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
 INSTALL (FILES rpmconf.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
+INSTALL (FILES snapper.conf DESTINATION ${SYSCONFDIR}/dnf/plugins)
 endif()

--- a/etc/dnf/plugins/snapper.conf
+++ b/etc/dnf/plugins/snapper.conf
@@ -1,0 +1,2 @@
+[main]
+snapper_config = root

--- a/plugins/snapper.py
+++ b/plugins/snapper.py
@@ -34,6 +34,13 @@ class Snapper(dnf.Plugin):
         self._pre_snap_created = False
         self._snapper = None
         self._pre_snap_number = None
+        self._snapper_config = "root"
+
+    def config(self):
+        conf = self.read_config(self.base.conf)
+
+        if conf.has_section("main") and conf.has_option("main", "snapper_config"):
+            self._snapper_config = conf.get("main", "snapper_config")
 
     def pre_transaction(self):
         if not self.base.transaction:
@@ -54,7 +61,8 @@ class Snapper(dnf.Plugin):
             logger.debug(
                 "snapper: " + _("creating pre_snapshot")
             )
-            self._pre_snap_number = self._snapper.CreatePreSnapshot("root", self.description,
+            self._pre_snap_number = self._snapper.CreatePreSnapshot(self._snapper_config,
+                                                                    self.description,
                                                                     "number", {})
             self._pre_snap_created = True
             logger.debug(
@@ -79,7 +87,8 @@ class Snapper(dnf.Plugin):
             logger.debug(
                 "snapper: " + _("creating post_snapshot")
             )
-            snap_post_number = self._snapper.CreatePostSnapshot("root", self._pre_snap_number,
+            snap_post_number = self._snapper.CreatePostSnapshot(self._snapper_config,
+                                                                self._pre_snap_number,
                                                                 self.description, "number", {})
             logger.debug(
                 "snapper: " + _("created post_snapshot %d"), snap_post_number


### PR DESCRIPTION
The snapper plugin fails if the snapper config for `/` is not named `root`:
```
snapper: creating pre_snapshot failed: error.unknown_config: org.freedesktop.DBus.Error.Failed
```
See https://bugzilla.redhat.com/show_bug.cgi?id=2089544

This PR implements a new "snapper_config" setting for specifying which config the plugin uses for creating snapshots. This allows the plugin to function on systems where the root snapper config is named something other than "root".
    
The setting defaults to "root" (as before) when not set.