### PR TITLE
Adapt rpmconf tests to RPM 4.19 without rpm.fi

### DIFF
--- a/dnf-plugins-extras.spec
+++ b/dnf-plugins-extras.spec
@@ -18,6 +18,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-dnf >= %{dnf_lowest_compatible}
 BuildRequires:  python3-pytest
 BuildRequires:  python3-sphinx
+BuildRequires:  python3-packaging
 
 %description
 Extras Plugins for DNF.

--- a/tests/test_rpmconf.py
+++ b/tests/test_rpmconf.py
@@ -27,6 +27,8 @@ from dnf.pycomp import StringIO
 
 import tests.support
 from tests.support import mock
+from importlib.metadata import version
+from packaging.version import parse
 
 from itertools import zip_longest
 
@@ -38,6 +40,10 @@ def create_file(path, content):
         f.write(content)
     return path, content
 
+class FakeRpmfile(object):
+    def __init__(self, conf_file, fflags):
+        self.name = conf_file
+        self.fflags = fflags
 
 class RpmconfPluginStub(object):
 
@@ -53,6 +59,8 @@ class RpmconfPluginStub(object):
         self._patches = [
             mock.patch("rpm.TransactionSet.dbMatch", return_value=self.packages),
             mock.patch("rpm.fi", return_value=((self._conf_file, None, None, None, 1), ))
+                if parse(version('rpmconf')) < parse('1.1.10') else
+                    mock.patch("rpm.files", return_value=(FakeRpmfile(self._conf_file, 1), ))
         ]
         for patch in self._patches:
             patch.__enter__()


### PR DESCRIPTION
RPM 4.19 removed rpm.fi class. rpmconf tool needs to move to rpm.files class <https://github.com/xsuchy/rpmconf/pull/53>. That in turn breaks tests/test_rpmconf.py which mocks rpmconf internals:

~~~~
tests/test_rpmconf.py:187:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ tests/test_rpmconf.py:58: in __enter__
    patch.__enter__()
/usr/lib64/python3.12/unittest/mock.py:1455: in __enter__
    original, local = self.get_original()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <unittest.mock._patch object at 0x7fa240b50b00>

    def get_original(self):
        target = self.getter()
        name = self.attribute

        original = DEFAULT
        local = False

        try:
            original = target.__dict__[name]
        except (AttributeError, KeyError):
            original = getattr(target, name, DEFAULT)
        else:
            local = True

        if name in _builtins and isinstance(target, ModuleType):
            self.create = True

        if not self.create and original is DEFAULT:
>           raise AttributeError(
                "%s does not have the attribute %r" % (target, name)
            )
E           AttributeError: <module 'rpm' from '/usr/lib64/python3.12/site-packages/rpm/__init__.py'> does not have the attribute 'fi'
~~~~

This patch adapts to the changes in rpmconf.

<https://bugzilla.redhat.com/show_bug.cgi?id=2219977>