### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,8 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration
 
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
+
 # To disable default jobs set them as empty
 jobs: []


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.

For rpm-software-management/ci-dnf-stack#1843

Build example: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10282758/